### PR TITLE
[Feat/#178] post 에 해시태그(enum) 추가

### DIFF
--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/FreePostSearchService.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/FreePostSearchService.java
@@ -112,7 +112,8 @@ public class FreePostSearchService {
                             post,
                             likedPostIds.contains(post.getId()),
                             scrappedPostIds.contains(post.getId()),
-                            commentedPostIds.contains(post.getId())
+                            commentedPostIds.contains(post.getId()),
+                            post.getHashtag() != null ? post.getHashtag() : Collections.emptyList()
                     ))
                     .toList();
 

--- a/src/main/java/com/ceos/beatbuddy/domain/post/controller/PostApiDocs.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/controller/PostApiDocs.java
@@ -4,6 +4,7 @@ import com.ceos.beatbuddy.domain.post.dto.*;
 import com.ceos.beatbuddy.global.SwaggerExamples;
 import com.ceos.beatbuddy.global.dto.ResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,8 +20,14 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 public interface PostApiDocs {
-    @Operation(summary = "#####게시물 생성 - 새로운 버전", description = "게시물을 생성합니다 (type: free/piece), 공통으로는 title(필수), content(필수), anonymous, venueId 입니다." +
-            "free: hashtag, piece: totalPrice, totalMembers, eventDate; ")
+    @Operation(summary = "#####게시물 생성 - 새로운 버전",
+            description = """
+            게시물을 생성합니다 (type: free/piece)
+            - 공통으로는 title(필수), content(필수), anonymous, venueId 입니다.
+            - free: hashtag (압구정로데오/홍대/이태원/강남.신사/뮤직/자유/번개 모임/International/19+/LGBTQ/짤.밈) 중 하나입니다.
+            - piece: totalPrice, totalMembers, eventDate
+            """
+    )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "게시물 생성 성공",
                     content = @Content(
@@ -43,17 +50,20 @@ public interface PostApiDocs {
                             }
                     """))
             ),
-            @ApiResponse(responseCode = "400", description = "잘못된 게시글 타입 요청",
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
                     content = @Content(
                             mediaType = "application/json",
-                            examples = @ExampleObject(name = "잘못된 type 예시", value = SwaggerExamples.INVALID_POST_TYPE)
+                            examples = {@ExampleObject(name = "잘못된 type 예시", value = SwaggerExamples.INVALID_POST_TYPE),
+                                        @ExampleObject(name = "중복된 해시태그", value = SwaggerExamples.DUPLICATED_HASHTAG),
+                            }
                     )
             ),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저, 베뉴가 존재하지 않는 경우",
+            @ApiResponse(responseCode = "404", description = "리소스 없음",
                     content = @Content(
                             mediaType = "application/json",
                             examples = {@ExampleObject(name = "존재하지 않는 유저", value = SwaggerExamples.MEMBER_NOT_EXIST),
-                                    @ExampleObject(name = "존재하지 않는 베뉴", value = SwaggerExamples.VENUE_NOT_EXIST)
+                                    @ExampleObject(name = "존재하지 않는 베뉴", value = SwaggerExamples.VENUE_NOT_EXIST),
+                                    @ExampleObject(name = "존재하지 않는 해시태그", value = SwaggerExamples.NOT_FOUND_HASHTAG)
                             }
                     )
             ),
@@ -63,10 +73,8 @@ public interface PostApiDocs {
                     content = @Content(
                             mediaType = "application/json",
                             examples = {
-                                    @ExampleObject(
-                                            name = "s3에 이미지 등록을 실패했을 경우", value = SwaggerExamples.IMAGE_UPLOAD_FAILED),
-                                    @ExampleObject(
-                                            name = "Elasticsearch에 게시글 등록을 실패했을 경우", value = SwaggerExamples.ELASTICSEARCH_POST_CREATE_FAILED)
+                                    @ExampleObject(name = "s3에 이미지 등록을 실패했을 경우", value = SwaggerExamples.IMAGE_UPLOAD_FAILED),
+                                    @ExampleObject(name = "Elasticsearch에 게시글 등록을 실패했을 경우", value = SwaggerExamples.ELASTICSEARCH_POST_CREATE_FAILED)
                             }
                     )
             )
@@ -234,51 +242,45 @@ public interface PostApiDocs {
 
     @Operation(summary = "게시물 조회", description = "게시물을 조회합니다 (type: free/piece)")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "선택한 포스트 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = PostListResponseDTO.class),
-                            examples = @ExampleObject(value = """
-                            {
-                              "status": 200,
-                              "code": "SUCCESS_GET_POST",
-                              "message": "포스트를 불러왔습니다",
-                              "data": {
-                                "id": 23,
-                                "title": "",
-                                "content": "",
-                                "thumbImage": "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/post/20250622_154930_3f228896-4a44-45a2-bccf-66ed9b7e966b.png",
-                                "role": "BUSINESS",
-                                "likes": 0,
-                                "scraps": 0,
-                                "comments": 0,
-                                "liked": false,
-                                "scrapped": false,
-                                "hasCommented": false,
-                                "nickname": "길동hong",
-                                "createAt": "2025-06-19",
-                                "imageUrls": [
-                                  "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/post/20250622_154930_3f228896-4a44-45a2-bccf-66ed9b7e966b.png"
-                                ],
-                                "views": 4
-                              }
-                            }
-                    """))
-            ),
-            @ApiResponse(responseCode = "400", description = "잘못된 게시글 타입 요청",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(name = "잘못된 type 예시", value = SwaggerExamples.INVALID_POST_TYPE))
-            ),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = { @ExampleObject(name = "존재하지 않는 유저", value = SwaggerExamples.MEMBER_NOT_EXIST),
-                                    @ExampleObject(
-                                            name = "존재하지 않는 포스트", value = SwaggerExamples.POST_NOT_EXIST)})
-            )
-
-    })
+    @ApiResponse(responseCode = "200", description = "선택한 포스트 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PostListResponseDTO.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "status": 200,
+                      "code": "SUCCESS_GET_POST",
+                      "message": "포스트를 불러왔습니다",
+                      "data": {
+                        "id": 23,
+                        "title": "",
+                        "content": "",
+                        "thumbImage": "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/post/20250622_154930_3f228896-4a44-45a2-bccf-66ed9b7e966b.png",
+                        "role": "BUSINESS",
+                        "likes": 0,
+                        "scraps": 0,
+                        "comments": 0,
+                        "liked": false,
+                        "scrapped": false,
+                        "hasCommented": false,
+                        "nickname": "길동hong",
+                        "createAt": "2025-06-19",
+                        "imageUrls": [
+                          "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/post/20250622_154930_3f228896-4a44-45a2-bccf-66ed9b7e966b.png"
+                        ],
+                        "views": 4
+                      }
+                    }
+            """))
+    ),
+    @ApiResponse(responseCode = "400", description = "잘못된 게시글 타입 요청",
+            content = @Content(mediaType = "application/json", examples = @ExampleObject(name = "잘못된 type 예시", value = SwaggerExamples.INVALID_POST_TYPE))
+    ),
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 유저",
+            content = @Content(mediaType = "application/json",
+                    examples = { @ExampleObject(name = "존재하지 않는 유저", value = SwaggerExamples.MEMBER_NOT_EXIST),
+                            @ExampleObject(name = "존재하지 않는 포스트", value = SwaggerExamples.POST_NOT_EXIST)})
+    )})
     ResponseEntity<ResponseDTO<PostReadDetailDTO>> newReadPost(
             @PathVariable String type,
             @PathVariable Long postId);
@@ -335,14 +337,8 @@ public interface PostApiDocs {
             @ApiResponse(responseCode = "404", description = "리소스 없음",
                     content = @Content(
                             mediaType = "application/json",
-                            examples = {@ExampleObject(
-                                    name = "유저가 존재하지 않음",
-                                    value = SwaggerExamples.MEMBER_NOT_EXIST
-                            ),
-                            @ExampleObject(
-                                    name = "글이 존재하지 않음",
-                                    value = SwaggerExamples.POST_NOT_EXIST
-                            )}
+                            examples = {@ExampleObject(name = "유저가 존재하지 않음", value = SwaggerExamples.MEMBER_NOT_EXIST),
+                            @ExampleObject(name = "글이 존재하지 않음", value = SwaggerExamples.POST_NOT_EXIST)}
                     )
             ),
             @ApiResponse(
@@ -364,5 +360,57 @@ public interface PostApiDocs {
             @RequestPart("updatePostRequestDTO") UpdatePostRequestDTO updatePostRequestDTO,
             @RequestPart(value = "files", required = false) List<MultipartFile> files
     );
+
+    @Operation(summary = "전체 게시물 조회, 최신순 정렬이 기본입니다.)", description = """
+    전체 게시물을 조회합니다 (type: free/piece), (sort: latest)
+    
+    """)
+    @ApiResponse(
+            responseCode = "200",
+            description = "게시글 목록 조회 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ResponseDTO.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "status": 200,
+                      "code": "SUCCESS_GET_POST_SORT_LIST",
+                      "message": "type 에 맞는 post를 불러왔습니다.",
+                      "data": {
+                        "totalPost": 44,
+                        "size": 10,
+                        "page": 1,
+                        "responseDTOS": [
+                          {
+                            "id": 537,
+                            "title": "string",
+                            "content": "string",
+                            "role": "USER",
+                            "likes": 0,
+                            "scraps": 0,
+                            "comments": 0,
+                            "liked": false,
+                            "scrapped": false,
+                            "hasCommented": false,
+                            "nickname": "BeatBuddy",
+                            "createAt": "2025-07-04",
+                            "hashtags": [
+                              "이태원",
+                              "홍대",
+                              "강남.신사"
+                            ]
+                          }
+                        ]
+                      }
+                    }
+        """)
+            )
+    )
+    ResponseEntity<ResponseDTO<PostListResponseDTO>> readAllPostsSort(
+            @PathVariable String type,
+            @Parameter(description = "페이지 번호")
+            @RequestParam(defaultValue = "1") int page,
+            @Parameter(description = "페이지 당 요청할 게시물 개수")
+            @RequestParam(defaultValue = "10") int size);
 
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/controller/PostController.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/controller/PostController.java
@@ -103,7 +103,7 @@ public class PostController implements PostApiDocs {
     }
 
 
-    @GetMapping("/{type}/sort/{sort}")
+    @GetMapping("/{type}/sorted")
     public ResponseEntity<ResponseDTO<PostListResponseDTO>> readAllPostsSort(
             @PathVariable String type,
             @Parameter(description = "페이지 번호")

--- a/src/main/java/com/ceos/beatbuddy/domain/post/controller/PostController.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/controller/PostController.java
@@ -102,54 +102,17 @@ public class PostController implements PostApiDocs {
         return ResponseEntity.ok(postService.readAllPosts(type, page, size));
     }
 
-    @Operation(summary = "전체 게시물 조회, 최신순 / 인기순 정렬이 추가되었습니다.)", description = "전체 게시물을 조회합니다 (type: free/piece), (sort: latest/popular)")
-    @ApiResponse(
-            responseCode = "200",
-            description = "게시글 목록 조회 성공",
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = ResponseDTO.class),
-                    examples = @ExampleObject(value = """
-                    {
-                      "status": 200,
-                      "code": "SUCCESS_GET_POST_SORT_LIST",
-                      "message": "type 에 맞는 post를 sort 해서 불러왔습니다.",
-                      "data": {
-                        "totalPost": 40,
-                        "size": 10,
-                        "page": 0,
-                        "responseDTOS": [
-                          {
-                            "id": 533,
-                            "title": "string",
-                            "content": "string",
-                            "role": "BUSINESS",
-                            "likes": 0,
-                            "scraps": 0,
-                            "comments": 0,
-                            "liked": false,
-                            "scrapped": false,
-                            "hasCommented": false,
-                            "nickname": "길동hong",
-                            "createAt": "2025-06-22"
-                          }
-                        ]
-                      }
-                    }
-        """)
-            )
-    )
+
     @GetMapping("/{type}/sort/{sort}")
-    public ResponseEntity<ResponseDTO<PostListResponseDTO>> readAllPosts(
+    public ResponseEntity<ResponseDTO<PostListResponseDTO>> readAllPostsSort(
             @PathVariable String type,
-            @PathVariable String sort,
             @Parameter(description = "페이지 번호")
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int page,
             @Parameter(description = "페이지 당 요청할 게시물 개수")
             @RequestParam(defaultValue = "10") int size) {
 
         Long memberId = SecurityUtils.getCurrentMemberId();
-        PostListResponseDTO result = postService.readAllPostsSort(memberId, type, sort, page, size);
+        PostListResponseDTO result = postService.readAllPostsSort(memberId, type, page, size);
 
         return ResponseEntity
                 .status(SuccessCode.SUCCESS_GET_POST_SORT_LIST.getStatus().value())

--- a/src/main/java/com/ceos/beatbuddy/domain/post/dto/PostCreateRequestDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/dto/PostCreateRequestDTO.java
@@ -1,6 +1,7 @@
 package com.ceos.beatbuddy.domain.post.dto;
 
 import com.ceos.beatbuddy.domain.member.entity.Member;
+import com.ceos.beatbuddy.domain.post.entity.FixedHashtag;
 import com.ceos.beatbuddy.domain.post.entity.FreePost;
 import com.ceos.beatbuddy.domain.post.entity.Piece;
 import com.ceos.beatbuddy.domain.post.entity.PiecePost;
@@ -26,16 +27,16 @@ public class PostCreateRequestDTO {
 
     private Boolean anonymous;
     private Long venueId;
-    private List<String> hashtag;
+    private List<String> hashtags;
 
     private int totalPrice;
     private int totalMembers;
     private LocalDateTime eventDate;
 
 
-    public static FreePost toEntity(PostCreateRequestDTO dto, List<String> imageUrls, Member member, Venue venue) {
+    public static FreePost toEntity(PostCreateRequestDTO dto, List<String> imageUrls, Member member, Venue venue, List<FixedHashtag> hashtag) {
         return FreePost.builder()
-                .hashtag(dto.getHashtag())
+                .hashtag(hashtag)
                 .imageUrls(imageUrls)
                 .title(dto.getTitle())
                 .content(dto.getContent())

--- a/src/main/java/com/ceos/beatbuddy/domain/post/dto/PostPageResponseDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/dto/PostPageResponseDTO.java
@@ -1,5 +1,7 @@
 package com.ceos.beatbuddy.domain.post.dto;
 
+import com.ceos.beatbuddy.domain.post.entity.FixedHashtag;
+import com.ceos.beatbuddy.domain.post.entity.FreePost;
 import com.ceos.beatbuddy.domain.post.entity.Post;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
@@ -8,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Builder
 @Getter
@@ -28,8 +31,9 @@ public class PostPageResponseDTO {
     private boolean hasCommented;
     private String nickname;
     private LocalDate createAt;
+    private List<String> hashtags;
 
-    public static PostPageResponseDTO toDTO(Post post, Boolean liked, Boolean scrapped, Boolean hasCommented) {
+    public static PostPageResponseDTO toDTO(Post post, Boolean liked, Boolean scrapped, Boolean hasCommented, List<FixedHashtag> hashtags) {
         return PostPageResponseDTO.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -44,6 +48,9 @@ public class PostPageResponseDTO {
                 .scrapped(scrapped)
                 .hasCommented(hasCommented)
                 .role(post.getMember().getRole().toString())
+                .hashtags(hashtags != null ? hashtags.stream()
+                        .map(FixedHashtag::getDisplayName)
+                        .toList() : List.of())
                 .build();
     }
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/dto/PostReadDetailDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/dto/PostReadDetailDTO.java
@@ -1,5 +1,7 @@
 package com.ceos.beatbuddy.domain.post.dto;
 
+import com.ceos.beatbuddy.domain.post.entity.FixedHashtag;
+import com.ceos.beatbuddy.domain.post.entity.FreePost;
 import com.ceos.beatbuddy.domain.post.entity.Post;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import lombok.AllArgsConstructor;
@@ -19,9 +21,9 @@ public class PostReadDetailDTO {
     private List<String> imageUrls;
     private int views;
 
-    public static PostReadDetailDTO toDTO(Post post, boolean liked, boolean scrapped, boolean commented) {
+    public static PostReadDetailDTO toDTO(Post post, boolean liked, boolean scrapped, boolean commented, List<FixedHashtag> hashtags) {
         return PostReadDetailDTO.builder()
-                .postPageResponseDTO(PostPageResponseDTO.toDTO(post, liked, scrapped, commented))
+                .postPageResponseDTO(PostPageResponseDTO.toDTO(post, liked, scrapped, commented, hashtags))
                 .imageUrls(post.getImageUrls())
                 .views(post.getViews())
                 .build();

--- a/src/main/java/com/ceos/beatbuddy/domain/post/entity/FixedHashtag.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/entity/FixedHashtag.java
@@ -1,0 +1,41 @@
+package com.ceos.beatbuddy.domain.post.entity;
+
+import com.ceos.beatbuddy.domain.post.exception.PostErrorCode;
+import com.ceos.beatbuddy.global.CustomException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+
+public enum FixedHashtag {
+    압구정로데오,
+    홍대,
+    이태원,
+    강남_신사,
+    뮤직,
+    자유,
+    번개_모임,
+    International,
+    NINETEEN_PLUS,
+    LGBTQ,
+    짤_밈;
+
+    @JsonValue
+    public String getDisplayName() {
+        return switch (this) {
+            case 강남_신사 -> "강남.신사";
+            case 번개_모임 -> "번개 모임";
+            case NINETEEN_PLUS -> "19+";
+            case 짤_밈 -> "짤.밈";
+            default -> this.name();
+        };
+    }
+
+    @JsonCreator
+    public static FixedHashtag fromDisplayName(String value) {
+        return Arrays.stream(FixedHashtag.values())
+                .filter(tag -> tag.getDisplayName().equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(PostErrorCode.NOT_FOUND_HASHTAG));
+    }
+}

--- a/src/main/java/com/ceos/beatbuddy/domain/post/entity/FreePost.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/entity/FreePost.java
@@ -27,5 +27,6 @@ public class FreePost extends Post{
 
     @ElementCollection
     @Getter
-    private List<String> hashtag;
+    @Enumerated(EnumType.STRING)
+    private List<FixedHashtag> hashtag;
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/entity/FreePostDocument.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/entity/FreePostDocument.java
@@ -27,7 +27,10 @@ public class FreePostDocument {
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
-                .hashtags(post.getHashtag())
+                .hashtags(post.getHashtag() != null ?
+                        post.getHashtag().stream()
+                                .map(FixedHashtag::getDisplayName)
+                                .toList() : List.of())
                 .build();
     }
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/exception/PostErrorCode.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/exception/PostErrorCode.java
@@ -6,12 +6,16 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum PostErrorCode implements ApiCode {
-    POST_NOT_EXIST(HttpStatus.NOT_FOUND, "존재하지 않는 포스트입니다."),
     INVALID_POST_TYPE(HttpStatus.BAD_REQUEST,"포스트의 type이 올바르지 않습니다"),
     INVALID_SORT_TYPE(HttpStatus.BAD_REQUEST,"포스트의 sort_type이 올바르지 않습니다"),
-    PIECE_NOT_EXIST(HttpStatus.NOT_FOUND, "존재하지 않는 조각입니다."),
+    DUPLICATE_HASHTAG_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "해시태그는 중복될 수 없습니다."),
     INVALID_DTO_TYPE(HttpStatus.BAD_REQUEST, "잘못된 DTO TYPE입니다."),
+
+    PIECE_NOT_EXIST(HttpStatus.NOT_FOUND, "존재하지 않는 조각입니다."),
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
+    NOT_FOUND_HASHTAG(HttpStatus.NOT_FOUND, "존재하지 않는 해시태그입니다."),
+    POST_NOT_EXIST(HttpStatus.NOT_FOUND, "존재하지 않는 포스트입니다."),
+
 
 
     ;

--- a/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepository.java
@@ -1,5 +1,6 @@
 package com.ceos.beatbuddy.domain.post.repository;
 
+import com.ceos.beatbuddy.domain.post.entity.FixedHashtag;
 import com.ceos.beatbuddy.domain.post.entity.Post;
 
 import java.util.List;

--- a/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.ceos.beatbuddy.domain.post.repository;
 
+import com.ceos.beatbuddy.domain.post.entity.FixedHashtag;
 import com.ceos.beatbuddy.domain.post.entity.Post;
+import com.ceos.beatbuddy.domain.post.entity.QFreePost;
 import com.ceos.beatbuddy.domain.post.entity.QPost;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -26,5 +28,4 @@ public class PostQueryRepositoryImpl implements PostQueryRepository{
                 .limit(2)
                 .fetch();
     }
-
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostRepository.java
@@ -1,11 +1,14 @@
 package com.ceos.beatbuddy.domain.post.repository;
 
+import com.ceos.beatbuddy.domain.post.entity.FixedHashtag;
 import com.ceos.beatbuddy.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
@@ -17,4 +20,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Modifying
     @Query("UPDATE Post p SET p.likes = p.likes - 1 WHERE p.id = :postId")
     void decreaseLike(@Param("postId") Long postId);
+
+    @Query("select f.hashtag from FreePost f where f.id = :id")
+    List<FixedHashtag> findHashtagsByPostId(@Param("id") Long id);
 }

--- a/src/main/java/com/ceos/beatbuddy/global/SwaggerExamples.java
+++ b/src/main/java/com/ceos/beatbuddy/global/SwaggerExamples.java
@@ -167,6 +167,15 @@ public class SwaggerExamples {
         }
         """;
 
+    public static final String DUPLICATED_HASHTAG = """
+        {
+          "status": 400,
+          "error": "BAD_REQUEST",
+          "code": "DUPLICATED_HASHTAG",
+          "message": "해시태그는 중복될 수 없습니다."
+        }
+        """;
+
     /**
      * 403 권한 없음
      * */
@@ -308,6 +317,15 @@ public class SwaggerExamples {
           "error": "NOT_FOUND",
           "code": "NOT_FOUND_MAGAZINE",
           "message": "존재하지 않는 매거진입니다."
+        }
+        """;
+
+    public static final String NOT_FOUND_HASHTAG = """
+        {
+          "status": 404,
+          "error": "NOT_FOUND",
+          "code": "NOT_FOUND_HASHTAG",
+          "message": "존재하지 않는 해시태그입니다."
         }
         """;
 

--- a/src/main/java/com/ceos/beatbuddy/global/code/ErrorCode.java
+++ b/src/main/java/com/ceos/beatbuddy/global/code/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode implements ApiCode {
     NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
     // 댓글이 속하지 않을 때
     NOT_FOUND_COMMENT_IN_EVENT(HttpStatus.NOT_FOUND, "해당 댓글이 이벤트에 속하지 않습니다."),
+    // 존재하지 않는 해시태그를 선택했을 때
 
     /**
      * 409

--- a/src/main/java/com/ceos/beatbuddy/global/code/ErrorCode.java
+++ b/src/main/java/com/ceos/beatbuddy/global/code/ErrorCode.java
@@ -42,7 +42,6 @@ public enum ErrorCode implements ApiCode {
     NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
     // 댓글이 속하지 않을 때
     NOT_FOUND_COMMENT_IN_EVENT(HttpStatus.NOT_FOUND, "해당 댓글이 이벤트에 속하지 않습니다."),
-    // 존재하지 않는 해시태그를 선택했을 때
 
     /**
      * 409

--- a/src/main/java/com/ceos/beatbuddy/global/code/SuccessCode.java
+++ b/src/main/java/com/ceos/beatbuddy/global/code/SuccessCode.java
@@ -91,7 +91,7 @@ public enum SuccessCode implements ApiCode {
     /**
      * post
      * */
-    SUCCESS_GET_POST_SORT_LIST(HttpStatus.OK, "type 에 맞는 post를 sort 해서 불러왔습니다."),
+    SUCCESS_GET_POST_SORT_LIST(HttpStatus.OK, "type 에 맞는 post를 불러왔습니다."),
     SUCCESS_LIKE_POST(HttpStatus.CREATED, "좋아요를 눌렀습니다."),
     SUCCESS_SCRAP_POST(HttpStatus.CREATED, "스크랩을 완료했습니다."),
     GET_SCRAPPED_POST_LIST(HttpStatus.OK, "스크랩한 글을 불러왔습니다."),


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #178

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [x]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers

-

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 게시글 생성 시 해시태그 중복 및 유효성 검증이 추가되었습니다.
  * 고정 해시태그(FixedHashtag) 기능이 도입되어, 게시글에 지정된 해시태그만 사용할 수 있습니다.
  * 게시글 조회 및 목록 응답에 해시태그 정보가 포함됩니다.

* **버그 수정**
  * 페이지 번호가 1 미만일 경우 예외가 발생하도록 검증이 강화되었습니다.

* **문서화**
  * 해시태그 관련 에러 응답 예시가 API 문서에 추가되었습니다.
  * 게시글 목록 조회 관련 API 문서가 개선되었습니다.

* **기타**
  * 일부 필드 및 엔드포인트 명칭이 일관성 있게 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->