### PR TITLE
[Feat/#181] 해시태그로 글 조회하기 구현

### DIFF
--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/PiecePostHandler.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/PiecePostHandler.java
@@ -31,8 +31,9 @@ public class PiecePostHandler implements PostTypeHandler {
     }
 
     @Override
-    public PostListResponseDTO hashTagPostList(List<String> hashtags, int page, int size) {
+    public PostListResponseDTO hashTagPostList(List<String> hashtags, int page, int size, Member member) {
         throw new UnsupportedOperationException("PiecePost 생성 기능이 아직 구현되지 않았습니다.");
+
     }
 
     @Override

--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/PiecePostHandler.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/PiecePostHandler.java
@@ -2,6 +2,7 @@ package com.ceos.beatbuddy.domain.post.application;
 
 import com.ceos.beatbuddy.domain.member.entity.Member;
 import com.ceos.beatbuddy.domain.post.dto.PostCreateRequestDTO;
+import com.ceos.beatbuddy.domain.post.dto.PostListResponseDTO;
 import com.ceos.beatbuddy.domain.post.dto.UpdatePostRequestDTO;
 import com.ceos.beatbuddy.domain.post.entity.PiecePost;
 import com.ceos.beatbuddy.domain.post.entity.Post;
@@ -27,6 +28,11 @@ public class PiecePostHandler implements PostTypeHandler {
     @Override
     public boolean supports(Post post) {
         return post instanceof PiecePost;
+    }
+
+    @Override
+    public PostListResponseDTO hashTagPostList(List<String> hashtags, int page, int size) {
+        throw new UnsupportedOperationException("PiecePost 생성 기능이 아직 구현되지 않았습니다.");
     }
 
     @Override

--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/PostService.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/PostService.java
@@ -172,10 +172,10 @@ public class PostService {
     }
 
     public PostListResponseDTO getHashtagPosts(Long memberId, List<String> hashtags, int page, int size) {
-        memberService.validateAndGetMember(memberId);
+        Member member = memberService.validateAndGetMember(memberId);
 
         PostTypeHandler handler = postTypeHandlerFactory.getHandler("free");
-        return handler.hashTagPostList(hashtags, page, size);
+        return handler.hashTagPostList(hashtags, page, size, member);
     }
 
 
@@ -222,7 +222,7 @@ public class PostService {
                 .map(Post::getId)
                 .toList();
 
-        // 4. 연관 정보 bulk 조회
+        // 4. 연관 정보 bulk 조회ㅎ
         Set<Long> likedPostIds = postLikeScrapService.getLikedPostIds(member.getId(), postIds);
 
         Set<Long> commentedPostIds = postLikeScrapService.getCommentedPostIds(member.getId(), postIds);

--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/PostService.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/PostService.java
@@ -53,20 +53,6 @@ public class PostService {
 
     private static final List<String> VALID_POST_TYPES = List.of("free", "piece");
 
-
-    // 프론트 개발 완료 후 삭제 예정
-    @Transactional
-    public Post addPost(Long memberId, String type, PostRequestDto requestDto) {
-        Member member = memberService.validateAndGetMember(memberId);
-        List<String> imageUrls = uploadUtil.uploadImages(requestDto.images(), UploadUtil.BucketType.MEDIA, "post");
-
-        return switch (type) {
-            case "free" -> createFreePost(member, requestDto, imageUrls);
-            case "piece" -> createPiecePost(member, requestDto, imageUrls);
-            default -> throw new CustomException(PostErrorCode.INVALID_POST_TYPE);
-        };
-    }
-
     @Transactional
     public ResponsePostDto addNewPost(String type, PostCreateRequestDTO dto, Long memberId, List<MultipartFile> images) {
         validatePostType(type);
@@ -86,25 +72,6 @@ public class PostService {
         return ResponsePostDto.of(post);
     }
 
-    
-    // 추후 삭제 예정
-    public Post readPost(String type, Long postId) {
-        switch (type) {
-            case "free" -> {
-                FreePost post = freePostRepository.findById(postId)
-                        .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_EXIST));
-                post.increaseView();  // 예: 조회수 증가
-                return post;
-            }
-            case "piece" -> {
-                PiecePost post = piecePostRepository.findById(postId)
-                        .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_EXIST));
-                post.increaseView();  // 예: 조회수 증가
-                return post;
-            }
-            default -> throw new CustomException(PostErrorCode.INVALID_POST_TYPE);
-        }
-    }
 
     @Transactional
     public PostReadDetailDTO newReadPost(String type, Long postId, Long memberId) {
@@ -122,16 +89,6 @@ public class PostService {
 
         // 4. 응답 생성
         return PostReadDetailDTO.toDTO(post, status.getLeft(), status.getMiddle(), status.getRight(), hashtags);
-    }
-
-    // 삭제 예정
-    public Page<ResponsePostDto> readAllPosts(String type, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        return switch (type) {
-            case "free" -> freePostRepository.findAll(pageable).map(ResponsePostDto::of);
-            case "piece" -> piecePostRepository.findAll(pageable).map(ResponsePostDto::of);
-            default -> throw new CustomException(PostErrorCode.INVALID_POST_TYPE);
-        };
     }
 
     public PostListResponseDTO readAllPostsSort(Long memberId, String type, int page, int size) {
@@ -214,6 +171,15 @@ public class PostService {
                 .toList();
     }
 
+    public PostListResponseDTO getHashtagPosts(Long memberId, List<String> hashtags, int page, int size) {
+        memberService.validateAndGetMember(memberId);
+
+        PostTypeHandler handler = postTypeHandlerFactory.getHandler("free");
+        return handler.hashTagPostList(hashtags, page, size);
+    }
+
+
+
     @Transactional
     public void deletePost(String type, Long postId, Long memberId) {
         Member member = memberService.validateAndGetMember(memberId);
@@ -229,49 +195,7 @@ public class PostService {
         handler.deletePost(postId, member);
     }
 
-    // 이후 삭제할 예정
-    private FreePost createFreePost(Member member, PostRequestDto requestDto, List<String> imageUrls) {
-        FreePost post = FreePost.builder()
-                .title(requestDto.title())
-                .content(requestDto.content())
-                .imageUrls(imageUrls)
-                .member(member)
-                .anonymous(requestDto.anonymous())
-                .build();
-        return freePostRepository.save(post);
-    }
 
-    // 삭제 예정
-    private PiecePost createPiecePost(Member member, PostRequestDto requestDto, List<String> imageUrls) {
-        Piece piece = pieceService.createPiece(member, requestDto.venueId(), (PiecePostRequestDto) requestDto);
-
-        PiecePost post = PiecePost.builder()
-                .title(requestDto.title())
-                .content(requestDto.content())
-                .imageUrls(imageUrls)
-                .member(member)
-                .anonymous(requestDto.anonymous())
-                .piece(piece)
-                .build();
-        return piecePostRepository.save(post);
-    }
-
-    // 삭제 예정
-    public Post findPostByIdWithDiscriminator(Long postId) {
-        // 먼저 자유 게시글 확인
-        Optional<FreePost> freePost = freePostRepository.findById(postId);
-        if (freePost.isPresent()) {
-            return freePost.get();
-        }
-
-        // 없다면 조각모집 게시글 확인
-        Optional<PiecePost> piecePost = piecePostRepository.findById(postId);
-        if (piecePost.isPresent()) {
-            return piecePost.get();
-        }
-
-        throw new CustomException(PostErrorCode.POST_NOT_EXIST);
-    }
 
     @Transactional(readOnly = true)
     public PostListResponseDTO getScrappedPostsByType(Long memberId, String type, int page, int size) {
@@ -457,4 +381,73 @@ public class PostService {
     }
 
 
+
+    // 이후 삭제할 예정
+    private FreePost createFreePost(Member member, PostRequestDto requestDto, List<String> imageUrls) {
+        FreePost post = FreePost.builder()
+                .title(requestDto.title())
+                .content(requestDto.content())
+                .imageUrls(imageUrls)
+                .member(member)
+                .anonymous(requestDto.anonymous())
+                .build();
+        return freePostRepository.save(post);
+    }
+
+    // 삭제 예정
+    private PiecePost createPiecePost(Member member, PostRequestDto requestDto, List<String> imageUrls) {
+        Piece piece = pieceService.createPiece(member, requestDto.venueId(), (PiecePostRequestDto) requestDto);
+
+        PiecePost post = PiecePost.builder()
+                .title(requestDto.title())
+                .content(requestDto.content())
+                .imageUrls(imageUrls)
+                .member(member)
+                .anonymous(requestDto.anonymous())
+                .piece(piece)
+                .build();
+        return piecePostRepository.save(post);
+    }
+
+    // 프론트 개발 완료 후 삭제 예정
+    @Transactional
+    public Post addPost(Long memberId, String type, PostRequestDto requestDto) {
+        Member member = memberService.validateAndGetMember(memberId);
+        List<String> imageUrls = uploadUtil.uploadImages(requestDto.images(), UploadUtil.BucketType.MEDIA, "post");
+
+        return switch (type) {
+            case "free" -> createFreePost(member, requestDto, imageUrls);
+            case "piece" -> createPiecePost(member, requestDto, imageUrls);
+            default -> throw new CustomException(PostErrorCode.INVALID_POST_TYPE);
+        };
+    }
+
+    // 삭제 예정
+    public Page<ResponsePostDto> readAllPosts(String type, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return switch (type) {
+            case "free" -> freePostRepository.findAll(pageable).map(ResponsePostDto::of);
+            case "piece" -> piecePostRepository.findAll(pageable).map(ResponsePostDto::of);
+            default -> throw new CustomException(PostErrorCode.INVALID_POST_TYPE);
+        };
+    }
+
+    // 추후 삭제 예정
+    public Post readPost(String type, Long postId) {
+        switch (type) {
+            case "free" -> {
+                FreePost post = freePostRepository.findById(postId)
+                        .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_EXIST));
+                post.increaseView();  // 예: 조회수 증가
+                return post;
+            }
+            case "piece" -> {
+                PiecePost post = piecePostRepository.findById(postId)
+                        .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_EXIST));
+                post.increaseView();  // 예: 조회수 증가
+                return post;
+            }
+            default -> throw new CustomException(PostErrorCode.INVALID_POST_TYPE);
+        }
+    }
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/PostTypeHandler.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/PostTypeHandler.java
@@ -59,7 +59,7 @@ public interface PostTypeHandler {
      */
     boolean supports(Post post);
 
-    PostListResponseDTO hashTagPostList(List<String> hashtags, int page, int size);
+    PostListResponseDTO hashTagPostList(List<String> hashtags, int page, int size, Member member    );
 
     Post updatePost(UpdatePostRequestDTO dto, Post post, Member member);
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/PostTypeHandler.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/PostTypeHandler.java
@@ -2,6 +2,7 @@ package com.ceos.beatbuddy.domain.post.application;
 
 import com.ceos.beatbuddy.domain.member.entity.Member;
 import com.ceos.beatbuddy.domain.post.dto.PostCreateRequestDTO;
+import com.ceos.beatbuddy.domain.post.dto.PostListResponseDTO;
 import com.ceos.beatbuddy.domain.post.dto.UpdatePostRequestDTO;
 import com.ceos.beatbuddy.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
@@ -57,6 +58,8 @@ public interface PostTypeHandler {
      * @return 지원 여부
      */
     boolean supports(Post post);
+
+    PostListResponseDTO hashTagPostList(List<String> hashtags, int page, int size);
 
     Post updatePost(UpdatePostRequestDTO dto, Post post, Member member);
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/controller/PostApiDocs.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/controller/PostApiDocs.java
@@ -413,4 +413,70 @@ public interface PostApiDocs {
             @Parameter(description = "페이지 당 요청할 게시물 개수")
             @RequestParam(defaultValue = "10") int size);
 
+
+
+    @Operation(summary = "해시태그로 게시글 목록 조회", description = """
+            해시태그로 게시글 목록을 조회합니다.
+            - hashtags: (압구정로데오/홍대/이태원/강남.신사/뮤직/자유/번개 모임/International/19+/LGBTQ/짤.밈) 중 하나입니다.
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "해시태그에 해당하는 포스트 목록을 성공적으로 조회했습니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PostListResponseDTO.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "status": 200,
+                              "code": "SUCCESS_GET_POST_LIST_BY_HASHTAG",
+                              "message": "해시태그에 해당하는 포스트 목록을 성공적으로 조회했습니다.",
+                              "data": {
+                                "totalPost": 1,
+                                "size": 10,
+                                "page": 1,
+                                "responseDTOS": [
+                                  {
+                                    "id": 537,
+                                    "title": "string",
+                                    "content": "string",
+                                    "role": "BUSINESS",
+                                    "likes": 0,
+                                    "scraps": 0,
+                                    "comments": 0,
+                                    "liked": false,
+                                    "scrapped": false,
+                                    "hasCommented": false,
+                                    "nickname": "BeatBuddy",
+                                    "createAt": "2025-07-04",
+                                    "hashtags": [
+                                      "이태원",
+                                      "홍대",
+                                      "강남.신사"
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                            """))
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {@ExampleObject(name = "중복된 해시태그", value = SwaggerExamples.DUPLICATED_HASHTAG),
+                                        @ExampleObject(name = "잘못된 페이지 요청", value = SwaggerExamples.PAGE_OUT_OF_BOUNDS)}
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "해시태그가 존재하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {@ExampleObject(name = "존재하지 않는 해시태그", value = SwaggerExamples.NOT_FOUND_HASHTAG)}
+                    )
+            )
+    })
+    ResponseEntity<ResponseDTO<PostListResponseDTO>> hashTagPostList(
+            @RequestParam List<String> hashtags,
+            @Parameter(description = "페이지 번호")
+            @RequestParam(defaultValue = "1") int page,
+            @Parameter(description = "페이지 당 요청할 게시물 개수")
+            @RequestParam(defaultValue = "10") int size);
+
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/controller/PostController.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/controller/PostController.java
@@ -196,4 +196,20 @@ public class PostController implements PostApiDocs {
                 .status(SuccessCode.SUCCESS_UPDATE_POST.getStatus().value())
                 .body(new ResponseDTO<>(SuccessCode.SUCCESS_UPDATE_POST, result));
     }
+
+    @Override
+    @GetMapping("/hashtags-search")
+    public     ResponseEntity<ResponseDTO<PostListResponseDTO>> hashTagPostList(
+            @RequestParam List<String> hashtags,
+            @Parameter(description = "페이지 번호")
+            @RequestParam(defaultValue = "1") int page,
+            @Parameter(description = "페이지 당 요청할 게시물 개수")
+            @RequestParam(defaultValue = "10") int size) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        PostListResponseDTO result = postService.getHashtagPosts(memberId, hashtags, page, size);
+
+        return ResponseEntity
+                .status(SuccessCode.SUCCESS_GET_POST_LIST_BY_HASHTAG.getStatus().value())
+                .body(new ResponseDTO<>(SuccessCode.SUCCESS_GET_POST_LIST_BY_HASHTAG, result));
+    }
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepository.java
@@ -1,10 +1,15 @@
 package com.ceos.beatbuddy.domain.post.repository;
 
 import com.ceos.beatbuddy.domain.post.entity.FixedHashtag;
+import com.ceos.beatbuddy.domain.post.entity.FreePost;
 import com.ceos.beatbuddy.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface PostQueryRepository {
     List<Post> findHotPostsWithin12Hours();
+
+    Page<FreePost> findPostsByHashtags(List<FixedHashtag> hashtags, Pageable pageable);
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepositoryImpl.java
@@ -44,6 +44,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository{
         // where 조건을 변수로 추출하여 중복 제거
         BooleanExpression whereCondition = freePost.hashtag.any().in(hashtags);
 
+        // 최신순 정렬
         JPQLQuery<FreePost> query = queryFactory
                 .selectFrom(freePost)
                 .where(whereCondition)

--- a/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.ceos.beatbuddy.domain.post.repository;
 
 import com.ceos.beatbuddy.domain.post.entity.*;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 
 @Repository
@@ -31,34 +33,33 @@ public class PostQueryRepositoryImpl implements PostQueryRepository{
     }
 
     @Override
-@Override
-public Page<FreePost> findPostsByHashtags(List<FixedHashtag> hashtags, Pageable pageable) {
-    QFreePost freePost = QFreePost.freePost;
-    
-    // 해시태그가 null이거나 비어있으면 빈 페이지 반환 (핸들러와 일관성 유지)
-    if (hashtags == null || hashtags.isEmpty()) {
-        return new PageImpl<>(Collections.emptyList(), pageable, 0);
+    public Page<FreePost> findPostsByHashtags(List<FixedHashtag> hashtags, Pageable pageable) {
+        QFreePost freePost = QFreePost.freePost;
+
+        // 해시태그가 null이거나 비어있으면 빈 페이지 반환 (핸들러와 일관성 유지)
+        if (hashtags == null || hashtags.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), pageable, 0);
+        }
+
+        // where 조건을 변수로 추출하여 중복 제거
+        BooleanExpression whereCondition = freePost.hashtag.any().in(hashtags);
+
+        JPQLQuery<FreePost> query = queryFactory
+                .selectFrom(freePost)
+                .where(whereCondition)
+                .orderBy(freePost.createdAt.desc());
+
+        List<FreePost> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long count = queryFactory
+                .select(freePost.count())
+                .from(freePost)
+                .where(whereCondition)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, count != null ? count : 0L);
     }
-
-    // where 조건을 변수로 추출하여 중복 제거
-    BooleanExpression whereCondition = freePost.hashtag.any().in(hashtags);
-
-    JPQLQuery<FreePost> query = queryFactory
-            .selectFrom(freePost)
-            .where(whereCondition)
-            .orderBy(freePost.createdAt.desc());
-
-    List<FreePost> content = query
-            .offset(pageable.getOffset())
-            .limit(pageable.getPageSize())
-            .fetch();
-
-    long count = queryFactory
-            .select(freePost.count())
-            .from(freePost)
-            .where(whereCondition)
-            .fetchOne();
-
-    return new PageImpl<>(content, pageable, count);
-}
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepositoryImpl.java
@@ -31,33 +31,34 @@ public class PostQueryRepositoryImpl implements PostQueryRepository{
     }
 
     @Override
-    public Page<FreePost> findPostsByHashtags(List<FixedHashtag> hashtags, Pageable pageable) {
-        QFreePost freePost = QFreePost.freePost;
-
-        JPQLQuery<FreePost> query = queryFactory
-                .selectFrom(freePost)
-                .where(
-                        hashtags == null || hashtags.isEmpty()
-                                ? null
-                                : freePost.hashtag.any().in(hashtags)
-                )
-                .orderBy(freePost.createdAt.desc());
-
-        List<FreePost> content = query
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
-
-        long count = queryFactory
-                .select(freePost.count())
-                .from(freePost)
-                .where(
-                        hashtags == null || hashtags.isEmpty()
-                                ? null
-                                : freePost.hashtag.any().in(hashtags)
-                )
-                .fetchOne();
-
-        return new PageImpl<>(content, pageable, count);
+@Override
+public Page<FreePost> findPostsByHashtags(List<FixedHashtag> hashtags, Pageable pageable) {
+    QFreePost freePost = QFreePost.freePost;
+    
+    // 해시태그가 null이거나 비어있으면 빈 페이지 반환 (핸들러와 일관성 유지)
+    if (hashtags == null || hashtags.isEmpty()) {
+        return new PageImpl<>(Collections.emptyList(), pageable, 0);
     }
+
+    // where 조건을 변수로 추출하여 중복 제거
+    BooleanExpression whereCondition = freePost.hashtag.any().in(hashtags);
+
+    JPQLQuery<FreePost> query = queryFactory
+            .selectFrom(freePost)
+            .where(whereCondition)
+            .orderBy(freePost.createdAt.desc());
+
+    List<FreePost> content = query
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+    long count = queryFactory
+            .select(freePost.count())
+            .from(freePost)
+            .where(whereCondition)
+            .fetchOne();
+
+    return new PageImpl<>(content, pageable, count);
+}
 }

--- a/src/main/java/com/ceos/beatbuddy/global/code/SuccessCode.java
+++ b/src/main/java/com/ceos/beatbuddy/global/code/SuccessCode.java
@@ -101,6 +101,7 @@ public enum SuccessCode implements ApiCode {
     SUCCESS_GET_POST(HttpStatus.OK, "포스트를 불러왔습니다"),
     SUCCESS_UPDATE_POST(HttpStatus.OK, "포스트를 수정했습니다."),
     SUCCESS_POST_SEARCH(HttpStatus.OK, "포스트 검색을 성공적으로 했습니다."),
+    SUCCESS_GET_POST_LIST_BY_HASHTAG(HttpStatus.OK, "해시태그에 해당하는 포스트 목록을 성공적으로 조회했습니다."),
 
     /**
      * Venue


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #181

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [x]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers

-

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 해시태그로 게시글을 검색할 수 있는 기능이 추가되었습니다. 해시태그 목록과 페이지 정보를 입력하면 해당 해시태그가 포함된 게시글을 페이징하여 조회할 수 있습니다.
  * 게시글 해시태그 검색 전용 API 엔드포인트(/post/hashtags-search)가 추가되었습니다.

* **문서화**
  * 해시태그 기반 게시글 조회 API에 대한 상세 문서 및 예시 응답이 추가되었습니다.

* **기타**
  * 해시태그 게시글 조회 성공 시 반환되는 새로운 성공 코드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->