### PR TITLE
[Feat/#187] 이미지 20장 초과하지 않도록 구현

### DIFF
--- a/src/main/java/com/ceos/beatbuddy/domain/post/controller/PostApiDocs.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/controller/PostApiDocs.java
@@ -66,6 +66,7 @@ public interface PostApiDocs {
                                               }
                                             }
                                           """),
+                                    @ExampleObject(name = "이미지 최대 20장", value = SwaggerExamples.TOO_MANY_IMAGES_20_EXAMPLE),
                             }
                     )
             ),
@@ -308,31 +309,39 @@ public interface PostApiDocs {
                                     name = "SuccessResponse",
                                     summary = "성공 응답 예시",
                                     value = """
-                        {
-                          "status": 200,
-                          "code": "SUCCESS_UPDATE_POST",
-                          "message": "포스트를 수정했습니다.",
-                          "data": {
-                            "id": 23,
-                            "title": "수정임",
-                            "content": "수정임",
-                            "thumbImage": "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/post/20250622_154930_3f228896-4a44-45a2-bccf-66ed9b7e966b.png",
-                            "role": "BUSINESS",
-                            "likes": 0,
-                            "scraps": 0,
-                            "comments": 0,
-                            "liked": false,
-                            "scrapped": false,
-                            "hasCommented": false,
-                            "nickname": "길동hong",
-                            "createAt": "2025-06-19",
-                            "imageUrls": [
-                              "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/post/20250622_154930_3f228896-4a44-45a2-bccf-66ed9b7e966b.png"
-                            ]
-                          }
-                        }
+                                    {
+                                      "status": 200,
+                                      "code": "SUCCESS_UPDATE_POST",
+                                      "message": "포스트를 수정했습니다.",
+                                      "data": {
+                                        "id": 23,
+                                        "title": "수정임",
+                                        "content": "수정임",
+                                        "thumbImage": "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/post/20250622_154930_3f228896-4a44-45a2-bccf-66ed9b7e966b.png",
+                                        "role": "BUSINESS",
+                                        "likes": 0,
+                                        "scraps": 0,
+                                        "comments": 0,
+                                        "liked": false,
+                                        "scrapped": false,
+                                        "hasCommented": false,
+                                        "nickname": "길동hong",
+                                        "createAt": "2025-06-19",
+                                        "imageUrls": [
+                                          "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/post/20250622_154930_3f228896-4a44-45a2-bccf-66ed9b7e966b.png"
+                                        ]
+                                      }
+                                    }
                         """
                             )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {@ExampleObject(name = "잘못된 type 예시", value = SwaggerExamples.INVALID_POST_TYPE),
+                                    @ExampleObject(name = "이미지 최대 20장", value = SwaggerExamples.TOO_MANY_IMAGES_20_EXAMPLE)
+                            }
                     )
             ),
             @ApiResponse(responseCode = "403", description = "권한 없음",

--- a/src/main/java/com/ceos/beatbuddy/global/SwaggerExamples.java
+++ b/src/main/java/com/ceos/beatbuddy/global/SwaggerExamples.java
@@ -115,6 +115,24 @@ public class SwaggerExamples {
         }
         """;
 
+    public static final String TOO_MANY_IMAGES_10_EXAMPLE = """
+        {
+          "status": 400,
+          "error": "BAD_REQUEST",
+          "code": "TOO_MANY_IMAGES_10",
+          "message": "이미지는 최대 10개까지 업로드할 수 있습니다."
+        }
+        """;
+
+    public static final String TOO_MANY_IMAGES_20_EXAMPLE = """
+        {
+          "status": 400,
+          "error": "BAD_REQUEST",
+          "code": "TOO_MANY_IMAGES_20",
+          "message": "이미지는 최대 20개까지 업로드할 수 있습니다."
+        }
+        """;
+
     public static final String SAME_NICKNAME = """
         {
           "status": 400,


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #187

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [x]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers

-

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 게시글 생성 및 수정 시 첨부 가능한 이미지 수가 최대 20장으로 제한됩니다. 이를 초과할 경우 오류가 발생합니다.

* **문서화**
  * 이미지 첨부 제한(최대 20장) 초과 시의 오류 예시가 API 문서에 추가되었습니다.
  * 최대 이미지 개수 제한(10장, 20장)에 대한 오류 응답 예시가 문서에 포함되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->