### PR TITLE
[Feat/#196] 매거진 수정 구현

### DIFF
--- a/src/main/java/com/ceos/beatbuddy/domain/magazine/application/MagazineService.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/magazine/application/MagazineService.java
@@ -320,14 +320,10 @@ public class MagazineService {
         if (dto.getSponsored() != null) magazine.setSponsored(dto.getSponsored());
         if (dto.getPicked() != null) magazine.setPicked(dto.getPicked());
 
-        // orderInHome은 null이 아닌 경우에만 수정
+        // 순서는 조건 검증 후 상위 로직에서 명확히 설정되므로,
+        // 여기선 수정 요청이 온 경우에만 반영
         if (dto.getOrderInHome() != null) {
             magazine.setOrderInHome(dto.getOrderInHome());
-        }
-
-        // pinned가 false로 명시된 경우 → 순서를 무조건 0으로
-        if (Boolean.FALSE.equals(dto.getPinned())) {
-            magazine.setOrderInHome(0);
         }
     }
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/magazine/controller/MagazineApiDocs.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/magazine/controller/MagazineApiDocs.java
@@ -1,9 +1,6 @@
 package com.ceos.beatbuddy.domain.magazine.controller;
 
-import com.ceos.beatbuddy.domain.magazine.dto.MagazineDetailDTO;
-import com.ceos.beatbuddy.domain.magazine.dto.MagazineHomeResponseDTO;
-import com.ceos.beatbuddy.domain.magazine.dto.MagazinePageResponseDTO;
-import com.ceos.beatbuddy.domain.magazine.dto.MagazineRequestDTO;
+import com.ceos.beatbuddy.domain.magazine.dto.*;
 import com.ceos.beatbuddy.global.SwaggerExamples;
 import com.ceos.beatbuddy.global.dto.ResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -125,6 +122,7 @@ public interface MagazineApiDocs {
                                                   "content": "매거진 1 1111111",
                                                   "liked": false,
                                                   "sponsored": false,
+                                                  "orderInHome": 1,
                                                   "picked": false,
                                                   "isAuthor": false
                                                 },
@@ -134,6 +132,7 @@ public interface MagazineApiDocs {
                                                   "title": "제목",
                                                   "content": "내용",
                                                   "liked": false,
+                                                  "orderInHome": 2,
                                                   "sponsored": false,
                                                   "picked": false,
                                                   "isAuthor": false
@@ -189,6 +188,9 @@ public interface MagazineApiDocs {
                                                             "thumbImage": "",
                                                             "views": 0,
                                                             "likes": 0,
+                                                            "visible": true,
+                                                            "pinned": true,
+                                                            "orderInHome": 2,
                                                             "createdAt": "2025-07-06T20:32:38.659096",
                                                             "liked": false,
                                                             "sponsored": true,
@@ -225,6 +227,9 @@ public interface MagazineApiDocs {
                                                             "thumbImage": "",
                                                             "views": 0,
                                                             "likes": 0,
+                                                            "visible": true,
+                                                            "pinned": true,
+                                                            "orderInHome": 2,
                                                             "createdAt": "2025-07-06T20:19:15.398591",
                                                             "liked": false,
                                                             "sponsored": false,
@@ -245,6 +250,9 @@ public interface MagazineApiDocs {
                                                             "thumbImage": "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/magazine/20250704_223543_68e20252-bce3-4b1d-892b-69f420c0cfa5.jpg",
                                                             "views": 0,
                                                             "likes": 0,
+                                                            "visible": true,
+                                                            "pinned": true,
+                                                            "orderInHome": 2,
                                                             "createdAt": "2025-07-04T22:35:43.57882",
                                                             "liked": false,
                                                             "sponsored": false,
@@ -308,6 +316,9 @@ public interface MagazineApiDocs {
                                 "thumbImage": "",
                                 "views": 1,
                                 "likes": 0,
+                                "visible": true,
+                                "pinned": true,
+                                "orderInHome": 2,
                                 "createdAt": "2025-07-06T20:32:38.659096",
                                 "liked": false,
                                 "sponsored": true,
@@ -352,4 +363,74 @@ public interface MagazineApiDocs {
             )
     })
     ResponseEntity<ResponseDTO<MagazineDetailDTO>> readDetailMagazine(@PathVariable Long magazineId);
+
+
+
+    @Operation(summary = "매거진 수정\n",
+            description = """
+                    매거진 수정 기능입니다. admin과 business 멤버에 한해서만 매거진을 수정할 수 있습니다.
+                    - 데이터 전달은 multipart/form-data이며, 'magazineRequestDTO'는 JSON 문자열 형태로 전송해야 합니다.
+                    - thumbnailImage: 매거진의 썸네일 이미지 (선택 사항)
+                    - images: 매거진의 이미지 리스트 (선택 사항)
+                    - ⚠️ 관련 venues는 해당 리스트로 전체 교체됩니다.
+                    - magazine의 총 이미지는 20장입니다.
+                    """)
+    @ApiResponse(
+            responseCode = "200",
+            description = "매거진이 성공적으로 수정되었습니다.",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ResponseDTO.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "status": 200,
+                      "code": "SUCCESS_UPDATE_MAGAZINE",
+                      "message": "매거진을 성공적으로 수정했습니다.",
+                      "data": {
+                        "magazineId": 3,
+                        "title": "string",
+                        "content": "string",
+                        "writerId": 156,
+                        "imageUrls": [
+                          "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/magazine/20250708_164100_799d623c-c00e-46af-8f95-17ec994ec9f9.jpg",
+                          "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/magazine/20250708_164100_3780705b-9378-4efb-a079-c9e58700a820.jpg",
+                          "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/magazine/20250708_164442_dec25cc8-c31d-495d-9f64-ac34299d6c93.jpg",
+                          "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/magazine/20250708_164443_9d9ec8e4-d0cb-40e8-9fdc-ae1893d4e5a6.jpg"
+                        ],
+                        "thumbImage": "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/magazine/20250708_163759_0cf4e15b-dbd0-473e-a30f-0bb206d9f623.png",
+                        "views": 0,
+                        "likes": 0,
+                        "createdAt": "2025-07-02T03:35:20.952583",
+                        "liked": false,
+                        "sponsored": false,
+                        "picked": false,
+                        "eventSimpleDTO": null,
+                        "venueSimpleDTOS": [
+                          {
+                            "venueId": 1,
+                            "koreanName": "클럽 트립",
+                            "englishName": "CLUB TRIP"
+                          },
+                          {
+                            "venueId": 2,
+                            "koreanName": "클럽 어스",
+                            "englishName": "CLUB US"
+                          },
+                          {
+                            "venueId": 3,
+                            "koreanName": "플러스82",
+                            "englishName": "PLUS82SEOUL"
+                          }
+                        ],
+                        "isAuthor": true
+                      }
+                    }
+                                    """)
+            )
+    )
+    ResponseEntity<ResponseDTO<MagazineDetailDTO>> updateMagazine(
+            @PathVariable Long magazineId,
+            @RequestPart("magazineRequestDTO") MagazineUpdateRequestDTO magazineRequestDTO,
+            @RequestPart(value = "thumbnailImage", required = false) MultipartFile thumbnailImage,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images);
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/magazine/controller/MagazineApiDocs.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/magazine/controller/MagazineApiDocs.java
@@ -425,7 +425,47 @@ public interface MagazineApiDocs {
                         "isAuthor": true
                       }
                     }
-                                    """)
+                """)
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (홈에서의 순서가 잘못되었거나 중복된 경우)",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = {
+                            @ExampleObject(name = "홈에서의 순서가 잘못되었습니다.", value = SwaggerExamples.INVALID_ORDER_IN_HOME),
+                            @ExampleObject(name = "홈에서의 순서가 중복되었습니다.", value = SwaggerExamples.DUPLICATE_ORDER_IN_HOME),
+                            @ExampleObject(name = "잘못된 이미지 삭제 요청", value = SwaggerExamples.INVALID_IMAGE_DELETE_REQUEST)
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "리소스를 찾을 수 없음",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = {
+                            @ExampleObject(name = "존재하지 않는 유저", value = SwaggerExamples.MEMBER_NOT_EXIST),
+                            @ExampleObject(name = "존재하지 않는 매거진", value = SwaggerExamples.NOT_FOUND_MAGAZINE)
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "403",
+            description = "잘못된 요청 (권한이 없는 일반 유저)",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(name = "권한 없는 유저", value = SwaggerExamples.UNAUTHORIZED_MEMBER)
+            )
+    )
+    @ApiResponse(
+            responseCode = "500",
+            description = "서버 오류",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = {@ExampleObject(name = "S3 이미지 업로드 실패", value = SwaggerExamples.IMAGE_UPLOAD_FAILED),
+                            @ExampleObject(name = "S3 이미지 삭제 실패", value = SwaggerExamples.IMAGE_DELETE_FAILED)}
             )
     )
     ResponseEntity<ResponseDTO<MagazineDetailDTO>> updateMagazine(

--- a/src/main/java/com/ceos/beatbuddy/domain/magazine/controller/MagazineController.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/magazine/controller/MagazineController.java
@@ -1,10 +1,7 @@
 package com.ceos.beatbuddy.domain.magazine.controller;
 
 import com.ceos.beatbuddy.domain.magazine.application.MagazineService;
-import com.ceos.beatbuddy.domain.magazine.dto.MagazineDetailDTO;
-import com.ceos.beatbuddy.domain.magazine.dto.MagazineHomeResponseDTO;
-import com.ceos.beatbuddy.domain.magazine.dto.MagazinePageResponseDTO;
-import com.ceos.beatbuddy.domain.magazine.dto.MagazineRequestDTO;
+import com.ceos.beatbuddy.domain.magazine.dto.*;
 import com.ceos.beatbuddy.global.code.SuccessCode;
 import com.ceos.beatbuddy.global.config.jwt.SecurityUtils;
 import com.ceos.beatbuddy.global.dto.ResponseDTO;
@@ -90,5 +87,21 @@ public class MagazineController implements MagazineApiDocs{
         return ResponseEntity
                 .status(SuccessCode.SUCCESS_GET_MAGAZINE_LIST.getStatus().value())
                 .body(new ResponseDTO<>(SuccessCode.SUCCESS_GET_MAGAZINE_LIST, result));
+    }
+
+    // 매거진 수정
+    @Override
+    @PatchMapping(value = "/{magazineId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ResponseDTO<MagazineDetailDTO>> updateMagazine(
+            @PathVariable Long magazineId,
+            @RequestPart("magazineRequestDTO") MagazineUpdateRequestDTO magazineRequestDTO,
+            @RequestPart(value = "thumbnailImage", required = false) MultipartFile thumbnailImage,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        MagazineDetailDTO result = magazineService.updateMagazine(memberId, magazineId, magazineRequestDTO, images, thumbnailImage);
+
+        return ResponseEntity
+                .status(SuccessCode.SUCCESS_UPDATE_MAGAZINE.getStatus().value())
+                .body(new ResponseDTO<>(SuccessCode.SUCCESS_UPDATE_MAGAZINE, result));
     }
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/magazine/dto/MagazineDetailDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/magazine/dto/MagazineDetailDTO.java
@@ -23,6 +23,9 @@ public class MagazineDetailDTO {
     private String thumbImage; // 썸네일 이미지 URL
     private int views;
     private int likes;
+    private boolean visible; // 매거진이 보이는지 여부
+    private boolean pinned; // 매거진이 고정되어 있는지 여부
+    private int orderInHome; // 홈에서의 순서
     private LocalDateTime createdAt;
     private boolean liked; // 좋아요 여부
     private boolean sponsored; // 스폰서 매거진인지 여부
@@ -47,6 +50,9 @@ public class MagazineDetailDTO {
                 .writerId(magazine.getMember().getId())
                 .likes(magazine.getLikes())
                 .views(magazine.getViews())
+                .pinned(magazine.isPinned())
+                .orderInHome(magazine.getOrderInHome())
+                .visible(magazine.isVisible())
                 .createdAt(magazine.getCreatedAt())
                 .liked(isLiked)
                 .picked(magazine.isPicked())

--- a/src/main/java/com/ceos/beatbuddy/domain/magazine/dto/MagazineHomeResponseDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/magazine/dto/MagazineHomeResponseDTO.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 public class MagazineHomeResponseDTO {
     private Long magazineId;
     private String thumbImageUrl;
+    private int orderInHome; // 홈에서의 순서
     private String title;
     private String content;
     private boolean liked;
@@ -32,6 +33,7 @@ public class MagazineHomeResponseDTO {
                 .thumbImageUrl(magazine.getThumbImage() != null ? magazine.getThumbImage() : "")
                 .title(magazine.getTitle())
                 .content(magazine.getContent())
+                .orderInHome(magazine.getOrderInHome())
                 .liked(liked)
                 .picked(magazine.isPicked())
                 .sponsored(magazine.isSponsored())

--- a/src/main/java/com/ceos/beatbuddy/domain/magazine/dto/MagazineUpdateRequestDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/magazine/dto/MagazineUpdateRequestDTO.java
@@ -1,0 +1,29 @@
+package com.ceos.beatbuddy.domain.magazine.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class MagazineUpdateRequestDTO {
+    private String title;
+    private String content;
+
+    private Boolean visible;
+    private Boolean pinned;
+    private Boolean sponsored;
+    private Boolean picked;
+
+    private Integer orderInHome;
+
+    private Long eventId; // 연동할 Event ID
+    private List<Long> venueIds; // venue ID 리스트
+
+    private List<String> deleteImageUrls; // 삭제할 기존 이미지 URL
+    // 이미지는 MultipartFile로 Controller에서 받음
+}

--- a/src/main/java/com/ceos/beatbuddy/domain/magazine/entity/Magazine.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/magazine/entity/Magazine.java
@@ -75,7 +75,13 @@ public class Magazine extends BaseTimeEntity {
 
     public void setEvent(Event event) {this.event = event;
     }
-
+    public void setTitle(String title) { this.title = title; }
+    public void setContent(String content) { this.content = content; }
+    public void setVisible(boolean visible) { this.isVisible = visible; }
+    public void setPinned(boolean pinned) { this.isPinned = pinned; }
+    public void setSponsored(boolean sponsored) { this.isSponsored = sponsored; }
+    public void setPicked(boolean picked) { this.isPicked = picked; }
+    public void setOrderInHome(int order) { this.orderInHome = order; }
     public void setVenues(List<Venue> venues) {
         this.venues = venues;
     }

--- a/src/main/java/com/ceos/beatbuddy/domain/magazine/exception/MagazineErrorCode.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/magazine/exception/MagazineErrorCode.java
@@ -10,7 +10,7 @@ public enum MagazineErrorCode implements ApiCode {
     MAGAZINE_NOT_EXIST(HttpStatus.NOT_FOUND, "해당 매거진을 찾을 수 없습니다."),
     INVALID_ORDER_IN_HOME(HttpStatus.BAD_REQUEST, "홈에서의 순서가 잘못되었습니다. 고정된 매거진은 1 이상의 순서를 가져야 합니다."),
     DUPLICATE_ORDER_IN_HOME(HttpStatus.BAD_REQUEST, "홈에서의 순서가 중복되었습니다. 이미 존재하는 순서를 사용하고 있습니다."),
-
+    INVALID_IMAGE_DELETE_REQUEST(HttpStatus.BAD_REQUEST, "삭제할 이미지 URL이 잘못되었습니다. 삭제할 이미지가 존재하지 않거나, 이미 삭제된 이미지입니다."),
 
     ;
 //    POST_NOT_EXIST(HttpStatus.NOT_FOUND, "존재하지 않는 포스트입니다."),

--- a/src/main/java/com/ceos/beatbuddy/domain/magazine/repository/MagazineRepository.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/magazine/repository/MagazineRepository.java
@@ -13,9 +13,7 @@ import java.util.Optional;
 @Repository
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     List<Magazine> findMagazinesByIsVisibleTrue();
-
     Optional<Magazine> findByIdAndIsVisibleTrue(Long id);
-
     @Modifying
     @Query("UPDATE Magazine m SET m.likes = m.likes + 1 WHERE m.id = :magazineId")
     void increaseLike(@Param("magazineId") Long magazineId);
@@ -26,4 +24,6 @@ public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     void decreaseLike(@Param("magazineId") Long magazineId);
 
     boolean existsByIsPinnedTrueAndOrderInHome(int orderInHome);
+    boolean existsByIsPinnedTrueAndOrderInHomeAndIdNot(int orderInHome, Long excludingId);
+
 }

--- a/src/main/java/com/ceos/beatbuddy/global/SwaggerExamples.java
+++ b/src/main/java/com/ceos/beatbuddy/global/SwaggerExamples.java
@@ -213,6 +213,19 @@ public class SwaggerExamples {
         }
         """;
 
+    public static final String INVALID_IMAGE_DELETE_REQUEST = """
+        {
+          "status": 400,
+          "error": "BAD_REQUEST",
+          "code": "INVALID_IMAGE_DELETE_REQUEST",
+          "message": "삭제할 이미지 URL이 잘못되었습니다. 삭제할 이미지가 존재하지 않거나, 이미 삭제된 이미지입니다."
+        }
+        """;
+
+    /**
+     * 404
+     * */
+
     public static final String COUPON_NOT_FOUND = """
         {
           "status": 404,

--- a/src/main/java/com/ceos/beatbuddy/global/code/SuccessCode.java
+++ b/src/main/java/com/ceos/beatbuddy/global/code/SuccessCode.java
@@ -49,6 +49,7 @@ public enum SuccessCode implements ApiCode {
     SUCCESS_DELETE_SCRAP(HttpStatus.OK, "스크랩을 취소했습니다."),
     SUCCESS_LIKE_MAGAZINE(HttpStatus.CREATED, "매거진에 성공적으로 좋아요를 표시했습니다."),
     SUCCESS_DELETE_LIKE(HttpStatus.OK, "좋아요를 취소했습니다."),
+    SUCCESS_UPDATE_MAGAZINE(HttpStatus.OK, "매거진을 성공적으로 수정했습니다."),
 
     /**
      * Event


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #196

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [x]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers

-

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 매거진 수정 기능이 추가되어 관리자가 매거진 정보를 업데이트할 수 있습니다.
  * 매거진 수정 시 썸네일 및 이미지 관리, 이미지 삭제, 최대 이미지 수 제한(20장) 기능이 적용됩니다.
  * 매거진의 홈 노출 순서(orderInHome), 공개 여부(visible), 상단 고정 여부(pinned) 등 추가 필드가 상세/목록 응답에 포함됩니다.

* **문서화**
  * 매거진 수정 API가 문서에 추가되고, 응답 예시에 새로운 필드가 반영되었습니다.
  * 이미지 삭제 관련 오류 응답 예시가 추가되었습니다.

* **기타**
  * 매거진 수정 성공 시 새로운 성공 메시지가 제공됩니다.
  * 이미지 삭제 요청 오류에 대한 새로운 에러 메시지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->