### PR TITLE
[Refactor/#248] 페이지네이션 시작 번호 일관성 유지

### DIFF
--- a/src/main/java/com/ceos/beatbuddy/domain/comment/application/CommentService.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/comment/application/CommentService.java
@@ -87,7 +87,11 @@ public class CommentService {
     }
 
     public Page<CommentResponseDto> getAllComments(Long postId, int page, int size, Long memberId) {
-        Pageable pageable = PageRequest.of(page, size);
+        // 페이지 유효성 조회
+        if (page < 1) {
+            throw new CustomException(ErrorCode.PAGE_OUT_OF_BOUNDS);
+        }
+        Pageable pageable = PageRequest.of(page-1, size);
         Page<Comment> comments = commentRepository.findAllByPost_Id(postId, pageable);
 
         Set<Long> followingIds = followRepository.findFollowingMemberIds(memberId);

--- a/src/main/java/com/ceos/beatbuddy/domain/comment/presentation/CommentController.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/comment/presentation/CommentController.java
@@ -75,7 +75,7 @@ public class CommentController {
     })
     public ResponseEntity<Page<CommentResponseDto>> getAllComments(
             @PathVariable Long postId,
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         return ResponseEntity.ok(commentService.getAllComments(postId, page, size, memberId));


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #248

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [x]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers

-

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 댓글 목록 조회 시 잘못된 페이지 번호(1 미만) 입력 시 오류 메시지가 표시됩니다.
  * 페이지네이션 기본값이 0에서 1로 변경되어, 첫 페이지가 1번 페이지로 시작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->