### PR TITLE
🔧 [FIX] Post 삭제 시 외래키 제약 조건 오류 해결 및 엔티티 관계 개선

### DIFF
--- a/src/main/java/com/ceos/beatbuddy/domain/comment/entity/Comment.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/comment/entity/Comment.java
@@ -2,6 +2,7 @@ package com.ceos.beatbuddy.domain.comment.entity;
 
 import com.ceos.beatbuddy.domain.member.entity.Member;
 import com.ceos.beatbuddy.domain.post.entity.Post;
+import com.ceos.beatbuddy.domain.scrapandlike.entity.CommentLike;
 import com.ceos.beatbuddy.global.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -9,7 +10,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.lang.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -44,6 +50,14 @@ public class Comment extends BaseTimeEntity {
     private boolean isDeleted;
 
     private int likes;
+
+    // 대댓글 컬렉션 OK
+    @OneToMany(mappedBy = "reply", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<Comment> children = new ArrayList<>();
+
+    // ✅ 댓글 좋아요는 CommentLike의 'comment' 필드가 주인
+    @OneToMany(mappedBy = "comment", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<CommentLike> commentLikes = new ArrayList<>();
     public Long getPostId() {
         return this.post.getId();
     }

--- a/src/main/java/com/ceos/beatbuddy/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/comment/repository/CommentRepository.java
@@ -41,4 +41,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 특정 포스트의 모든 익명 닉네임 조회 (중복 제거)
     @Query("SELECT DISTINCT c.anonymousNickname FROM Comment c WHERE c.post.id = :postId AND c.isAnonymous = true AND c.anonymousNickname IS NOT NULL ORDER BY c.anonymousNickname")
     List<String> findDistinctAnonymousNicknamesByPostId(Long postId);
+    
+    // 특정 포스트의 모든 댓글 삭제
+    @Modifying
+    void deleteByPost_Id(Long postId);
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/event/entity/Event.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/entity/Event.java
@@ -3,6 +3,7 @@ package com.ceos.beatbuddy.domain.event.entity;
 import com.ceos.beatbuddy.domain.event.dto.EventUpdateRequestDTO;
 import com.ceos.beatbuddy.domain.event.exception.EventErrorCode;
 import com.ceos.beatbuddy.domain.member.entity.Member;
+import com.ceos.beatbuddy.domain.scrapandlike.entity.EventLike;
 import com.ceos.beatbuddy.domain.venue.entity.Venue;
 import com.ceos.beatbuddy.global.BaseTimeEntity;
 import com.ceos.beatbuddy.global.CustomException;
@@ -10,6 +11,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -93,6 +95,15 @@ public class Event extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Region region;
+
+    @OneToMany(mappedBy = "event", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<EventLike> eventLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "event", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<EventComment> eventComments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "event", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<EventAttendance> eventAttendances = new ArrayList<>();
 
     public enum Region {
         홍대,

--- a/src/main/java/com/ceos/beatbuddy/domain/event/exception/EventErrorCode.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/exception/EventErrorCode.java
@@ -21,8 +21,8 @@ public enum EventErrorCode implements ApiCode {
     ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이벤트에 대한 참석 정보를 찾을 수 없습니다."),
     REGION_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 지역입니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작 날짜가 종료 날짜보다 늦을 수 없습니다."),
-    MISSING_DATE(HttpStatus.BAD_REQUEST, "시작 날짜와 종료 날짜는 필수입니다.")
-    ;
+    MISSING_DATE(HttpStatus.BAD_REQUEST, "시작 날짜와 종료 날짜는 필수입니다."),
+    PAST_EVENT_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "과거 이벤트는 허용되지 않습니다."),;
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/src/main/java/com/ceos/beatbuddy/domain/member/entity/Member.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/member/entity/Member.java
@@ -1,16 +1,20 @@
 package com.ceos.beatbuddy.domain.member.entity;
 
+import com.ceos.beatbuddy.domain.event.entity.EventComment;
 import com.ceos.beatbuddy.domain.member.constant.Gender;
 import com.ceos.beatbuddy.domain.member.constant.Region;
 import com.ceos.beatbuddy.domain.member.constant.Role;
+import com.ceos.beatbuddy.domain.scrapandlike.entity.EventLike;
 import com.ceos.beatbuddy.global.BaseTimeEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.type.SetType;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -74,7 +78,6 @@ public class Member extends BaseTimeEntity {
     private PostProfileInfo postProfileInfo = new PostProfileInfo(
             null, null
     );
-
 
     public void saveConsents(Boolean isLocationConsent, Boolean isMarketingConsent) {
         this.isLocationConsent = isLocationConsent;

--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/PostService.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/PostService.java
@@ -1,6 +1,8 @@
 package com.ceos.beatbuddy.domain.post.application;
 
+import com.ceos.beatbuddy.domain.comment.entity.Comment;
 import com.ceos.beatbuddy.domain.comment.repository.CommentRepository;
+import com.ceos.beatbuddy.domain.scrapandlike.repository.CommentLikeRepository;
 import com.ceos.beatbuddy.domain.follow.repository.FollowRepository;
 import com.ceos.beatbuddy.domain.member.application.MemberService;
 import com.ceos.beatbuddy.domain.member.entity.Member;
@@ -43,6 +45,7 @@ public class PostService {
     private final PostScrapRepository postScrapRepository;
     private final PostQueryRepository postQueryRepository;
     private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
     private final PostTypeHandlerFactory postTypeHandlerFactory;
     private final ImageUploadService imageUploadService;
     private final UploadUtilAsyncWrapper uploadUtilAsyncWrapper;
@@ -55,7 +58,8 @@ public class PostService {
 
     public PostService(MemberService memberService, PostLikeRepository postLikeRepository,
                        PostScrapRepository postScrapRepository, PostQueryRepository postQueryRepository,
-                       CommentRepository commentRepository, PostTypeHandlerFactory postTypeHandlerFactory,
+                       CommentRepository commentRepository, CommentLikeRepository commentLikeRepository,
+                       PostTypeHandlerFactory postTypeHandlerFactory,
                        ImageUploadService imageUploadService, UploadUtilAsyncWrapper uploadUtilAsyncWrapper,
                        PostRepository postRepository, PostInteractionService postInteractionService,
                        FollowRepository followRepository, UploadUtil uploadUtil) {
@@ -64,6 +68,7 @@ public class PostService {
         this.postScrapRepository = postScrapRepository;
         this.postQueryRepository = postQueryRepository;
         this.commentRepository = commentRepository;
+        this.commentLikeRepository = commentLikeRepository;
         this.postTypeHandlerFactory = postTypeHandlerFactory;
         this.imageUploadService = imageUploadService;
         this.uploadUtilAsyncWrapper = uploadUtilAsyncWrapper;

--- a/src/main/java/com/ceos/beatbuddy/domain/post/entity/Post.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/entity/Post.java
@@ -1,6 +1,8 @@
 package com.ceos.beatbuddy.domain.post.entity;
 
+import com.ceos.beatbuddy.domain.comment.entity.Comment;
 import com.ceos.beatbuddy.domain.member.entity.Member;
+import com.ceos.beatbuddy.domain.scrapandlike.entity.PostLike;
 import com.ceos.beatbuddy.domain.scrapandlike.entity.PostScrap;
 import com.ceos.beatbuddy.global.BaseTimeEntity;
 import com.ceos.beatbuddy.global.util.StringListConverter;
@@ -53,6 +55,16 @@ public abstract class Post extends BaseTimeEntity {
     @JoinColumn(name = "memberId")
     @Setter(PROTECTED)
     private Member member;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> commentList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostScrap> postScraps = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostLike> postLikes = new ArrayList<>();
+
 
     protected Post(String title, String content, Boolean anonymous,
                    List<String> imageUrls, Member member) {

--- a/src/main/java/com/ceos/beatbuddy/domain/scrapandlike/entity/CommentLike.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/scrapandlike/entity/CommentLike.java
@@ -22,8 +22,8 @@ public class CommentLike {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "memberId", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "memberId", nullable = true)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/ceos/beatbuddy/domain/scrapandlike/entity/EventLike.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/scrapandlike/entity/EventLike.java
@@ -19,9 +19,9 @@ public class EventLike extends BaseTimeEntity {
     @EmbeddedId
     private EventInteractionId id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
     @MapsId("memberId")
-    @JoinColumn(name = "memberId")
+    @JoinColumn(name = "memberId", nullable = true)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/ceos/beatbuddy/domain/scrapandlike/entity/MagazineLike.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/scrapandlike/entity/MagazineLike.java
@@ -19,9 +19,9 @@ public class MagazineLike extends BaseTimeEntity {
     @EmbeddedId
     private MagazineInteractionId id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
     @MapsId("memberId")
-    @JoinColumn(name = "memberId")
+    @JoinColumn(name = "memberId", nullable = true)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/ceos/beatbuddy/domain/scrapandlike/entity/PostLike.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/scrapandlike/entity/PostLike.java
@@ -19,9 +19,9 @@ public class PostLike extends BaseTimeEntity {
     @EmbeddedId
     private PostInteractionId id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
     @MapsId("memberId")
-    @JoinColumn(name = "memberId")
+    @JoinColumn(name = "memberId", nullable = true)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/ceos/beatbuddy/domain/scrapandlike/entity/PostScrap.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/scrapandlike/entity/PostScrap.java
@@ -19,9 +19,9 @@ public class PostScrap extends BaseTimeEntity {
     @EmbeddedId
     private PostInteractionId id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
     @MapsId("memberId")
-    @JoinColumn(name = "memberId")
+    @JoinColumn(name = "memberId", nullable = true)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/ceos/beatbuddy/domain/scrapandlike/entity/VenueReviewLike.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/scrapandlike/entity/VenueReviewLike.java
@@ -18,9 +18,9 @@ public class VenueReviewLike extends BaseTimeEntity {
     @EmbeddedId
     private VenueReviewLikeId id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
     @MapsId("memberId")
-    @JoinColumn(name = "memberId")
+    @JoinColumn(name = "memberId", nullable = true)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #327

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers
- PostService.deletePost()에서 삭제 순서 변경: CommentLike → Comment → Post
- CommentRepository에 deleteByPost_Id 메서드 추가
- JPA @OneToMany 관계에 cascade, orphanRemoval 설정 추가
- 외래키 제약 조건으로 인한 DataIntegrityViolationException 해결

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->