### PR TITLE
[Feat/#329] Add date range filtering to event search API

### DIFF
--- a/src/main/java/com/ceos/beatbuddy/domain/event/controller/EventApiDocs.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/controller/EventApiDocs.java
@@ -1158,6 +1158,8 @@ public interface EventApiDocs {
     ResponseEntity<ResponseDTO<EventListResponseDTO>> searchEvents(
             @RequestParam String keyword,
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) java.time.LocalDateTime startDate,
+            @RequestParam(required = false) java.time.LocalDateTime endDate
     );
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/event/controller/EventController.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/controller/EventController.java
@@ -22,6 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -248,10 +249,12 @@ public class EventController implements EventApiDocs {
     public ResponseEntity<ResponseDTO<EventListResponseDTO>> searchEvents(
             @RequestParam String keyword,
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) LocalDateTime startDate,
+            @RequestParam(required = false) LocalDateTime endDate
     ) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        EventListResponseDTO results = eventElasticService.search(keyword, memberId, page, size);
+        EventListResponseDTO results = eventElasticService.search(keyword, memberId, page, size, startDate, endDate);
         return ResponseEntity
                 .status(SuccessCode.EVENT_SEARCH_SUCCESS.getStatus().value())
                 .body(new ResponseDTO<>(SuccessCode.EVENT_SEARCH_SUCCESS, results));


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #329

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers
- Added startDate and endDate optional parameters to search endpoint
- Implemented Elasticsearch date range filtering using event.startDate.lte(endDateTime) and event.endDate.gte(startDateTime) logic
- Added backward compatible overloaded method in EventElasticService
- Updated API documentation with new parameters

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->