### PR TITLE
[Feat/#368] event apply sns none null

### DIFF
--- a/src/main/java/com/ceos/beatbuddy/domain/event/application/EventValidator.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/application/EventValidator.java
@@ -77,7 +77,8 @@ public class EventValidator {
             if (event.isReceiveTotalCount() && dto.getTotalNumber() == null) {
                 throw new CustomException(EventErrorCode.MISSING_TOTAL_COUNT);
             }
-            if (event.isReceiveSNSId() && (isEmpty(dto.getSnsType()) || isEmpty(dto.getSnsId()))) {
+            if (event.isReceiveSNSId() && (isEmpty(dto.getSnsType()) || 
+                    (!isEmpty(dto.getSnsType()) && !"NONE".equalsIgnoreCase(dto.getSnsType()) && isEmpty(dto.getSnsId())))) {
                 throw new CustomException(EventErrorCode.MISSING_SNS_ID_OR_TYPE);
             }
             if (event.isReceiveMoney() && dto.getIsPaid() == null) {
@@ -151,6 +152,14 @@ public class EventValidator {
 
     // SNS 정보가 비어있을 때 예외 처리
     private void validateSnsInfo(EventAttendanceUpdateDTO dto, EventAttendance existing) {
+        // DTO에서 SNSType이 NONE인 경우 검증 제외
+        boolean dtoHasNone = "NONE".equalsIgnoreCase(dto.getSnsType());
+        boolean existingHasNone = "NONE".equalsIgnoreCase(existing.getSnsType());
+        
+        if (dtoHasNone || existingHasNone) {
+            return; // NONE인 경우 검증하지 않음
+        }
+        
         boolean dtoMissing = isEmpty(dto.getSnsType()) || isEmpty(dto.getSnsId());
         boolean existingMissing = isEmpty(existing.getSnsType()) || isEmpty(existing.getSnsId());
 

--- a/src/main/java/com/ceos/beatbuddy/domain/event/application/EventValidator.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/application/EventValidator.java
@@ -3,6 +3,7 @@ package com.ceos.beatbuddy.domain.event.application;
 import com.ceos.beatbuddy.domain.event.dto.EventAttendanceRequestDTO;
 import com.ceos.beatbuddy.domain.event.dto.EventAttendanceUpdateDTO;
 import com.ceos.beatbuddy.domain.event.dto.EventUpdateRequestDTO;
+import com.ceos.beatbuddy.domain.event.constant.SNSType;
 import com.ceos.beatbuddy.domain.event.entity.Event;
 import com.ceos.beatbuddy.domain.event.entity.EventAttendance;
 import com.ceos.beatbuddy.domain.event.entity.EventComment;
@@ -77,9 +78,11 @@ public class EventValidator {
             if (event.isReceiveTotalCount() && dto.getTotalNumber() == null) {
                 throw new CustomException(EventErrorCode.MISSING_TOTAL_COUNT);
             }
-            if (event.isReceiveSNSId() && (isEmpty(dto.getSnsType()) || 
-                    (!isEmpty(dto.getSnsType()) && !"NONE".equalsIgnoreCase(dto.getSnsType()) && isEmpty(dto.getSnsId())))) {
-                throw new CustomException(EventErrorCode.MISSING_SNS_ID_OR_TYPE);
+            if (event.isReceiveSNSId()) {
+                SNSType snsType = SNSType.fromString(dto.getSnsType());
+                if (isEmpty(dto.getSnsType()) || (!snsType.isNone() && isEmpty(dto.getSnsId()))) {
+                    throw new CustomException(EventErrorCode.MISSING_SNS_ID_OR_TYPE);
+                }
             }
             if (event.isReceiveMoney() && dto.getIsPaid() == null) {
                 throw new CustomException(EventErrorCode.MISSING_PAYMENT);
@@ -152,16 +155,16 @@ public class EventValidator {
 
     // SNS 정보가 비어있을 때 예외 처리
     private void validateSnsInfo(EventAttendanceUpdateDTO dto, EventAttendance existing) {
-        // DTO에서 SNSType이 NONE인 경우 검증 제외
-        boolean dtoHasNone = "NONE".equalsIgnoreCase(dto.getSnsType());
-        boolean existingHasNone = "NONE".equalsIgnoreCase(existing.getSnsType());
+        // DTO와 기존 데이터에서 SNSType이 NONE인 경우 검증 제외
+        boolean dtoHasNone = dto.getSnsType() != null && dto.getSnsType().isNone();
+        boolean existingHasNone = existing.getSnsType() != null && existing.getSnsType().isNone();
         
         if (dtoHasNone || existingHasNone) {
             return; // NONE인 경우 검증하지 않음
         }
         
-        boolean dtoMissing = isEmpty(dto.getSnsType()) || isEmpty(dto.getSnsId());
-        boolean existingMissing = isEmpty(existing.getSnsType()) || isEmpty(existing.getSnsId());
+        boolean dtoMissing = dto.getSnsType() == null || isEmpty(dto.getSnsId());
+        boolean existingMissing = existing.getSnsType() == null || isEmpty(existing.getSnsId());
 
         if (dtoMissing && existingMissing) {
             throw new CustomException(EventErrorCode.MISSING_SNS_ID_OR_TYPE);

--- a/src/main/java/com/ceos/beatbuddy/domain/event/constant/SNSType.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/constant/SNSType.java
@@ -1,5 +1,6 @@
 package com.ceos.beatbuddy.domain.event.constant;
 
+import com.ceos.beatbuddy.domain.event.exception.EventErrorCode;
 import com.ceos.beatbuddy.global.CustomException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,7 @@ public enum SNSType {
         try {
             return SNSType.valueOf(value.toUpperCase());
         } catch (IllegalArgumentException e) {
-            return CustomException;
+            throw new CustomException(EventErrorCode.SNS_TYPE_NOT_EXIST);
         }
     }
     

--- a/src/main/java/com/ceos/beatbuddy/domain/event/constant/SNSType.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/constant/SNSType.java
@@ -1,0 +1,31 @@
+package com.ceos.beatbuddy.domain.event.constant;
+
+import com.ceos.beatbuddy.global.CustomException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SNSType {
+    NONE("없음"),
+    INSTAGRAM("인스타그램"),
+    FACEBOOK("페이스북");
+
+    private final String displayName;
+
+    public static SNSType fromString(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return NONE;
+        }
+        
+        try {
+            return SNSType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return CustomException;
+        }
+    }
+    
+    public boolean isNone() {
+        return this == NONE;
+    }
+}

--- a/src/main/java/com/ceos/beatbuddy/domain/event/controller/EventApiDocs.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/controller/EventApiDocs.java
@@ -390,26 +390,11 @@ public interface EventApiDocs {
                             "views": 0,
                             "startDate": "2025-06-17T00:00:00",
                             "endDate": "2025-06-17T00:00:00",
+                            "receiveAccompany": false,
                             "location": "경기도 파주",
                             "isAuthor": false,
                             "region": "홍대",
                             "isAttending": false,
-                            "liked": false,
-                            "isFreeEntrance": false
-                          },
-                          {
-                            "eventId": 2,
-                            "title": "string",
-                            "content": "string",
-                            "thumbImage": "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/ae7cd814-fGroup%201000003259.png",
-                            "likes": 1,
-                            "views": 0,
-                            "startDate": "2025-06-18T00:00:00",
-                            "endDate": "2025-06-23T00:00:00",
-                            "location": "서울시",
-                            "isAuthor": false,
-                            "region": "홍대",
-                            "isAttending": true,
                             "liked": false,
                             "isFreeEntrance": false
                           }
@@ -468,6 +453,7 @@ public interface EventApiDocs {
                             "isAuthor": false,
                             "region": "홍대",
                             "isAttending": false,
+                            "receiveAccompany": false,
                             "liked": false,
                             "isFreeEntrance": false
                           }
@@ -524,22 +510,7 @@ public interface EventApiDocs {
                             "endDate": "2025-06-23T00:00:00",
                             "region": "홍대",
                             "isFreeEntrance": false,
-                            "isAttending": true,
-                            "isAuthor": true
-                          },
-                          {
-                            "eventId": 1,
-                            "title": "이벤트 시작",
-                            "content": "이게 바로 이트",
-                            "thumbImage": "https://beatbuddy.s3.ap-northeast-2.amazonaws.com/ddded007-dGroup%201000003259.png",
-                            "liked": false,
-                            "location": "경기도 파주",
-                            "likes": 5,
-                            "views": 29,
-                            "startDate": "2025-06-17T00:00:00",
-                            "endDate": "2025-06-17T00:00:00",
-                            "region": "강남_신사",
-                            "isFreeEntrance": false,
+                            "receiveAccompany": false,
                             "isAttending": true,
                             "isAuthor": true
                           }

--- a/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventAttendanceExportDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventAttendanceExportDTO.java
@@ -36,7 +36,7 @@ public class EventAttendanceExportDTO {
                 .name(entity.getName() != null ? entity.getName() : "-")
                 .gender(entity.getGender().getText() != null? entity.getGender().getText() : "-")
                 .phoneNumber(entity.getPhoneNumber() != null ? entity.getPhoneNumber() : "-")
-                .snsType(entity.getSnsType() != null ? entity.getSnsType() : "-")
+                .snsType(entity.getSnsType() != null ? entity.getSnsType().name() : "-")
                 .snsId(entity.getSnsId() != null ? entity.getSnsId() : "-")
                 .isPaid(entity.getHasPaid() != null ? entity.getHasPaid().toString() : "-")
                 .totalMember(entity.getTotalMember() != null? entity.getTotalMember().toString() : "-")

--- a/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventAttendanceRequestDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventAttendanceRequestDTO.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Schema(description = "이벤트 참석 요청 DTO")
 public class EventAttendanceRequestDTO {
-    @Schema(description = "이벤트 ID", example = "1")
+    @Schema(description = "이름", example = "홍길동")
     private String name;
     @Schema(description = "성별 (MALE, FEMALE, None)", example = "MALE", allowableValues = "MALE, FEMALE, NONE")
     private String gender;

--- a/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventAttendanceRequestDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventAttendanceRequestDTO.java
@@ -2,6 +2,7 @@ package com.ceos.beatbuddy.domain.event.dto;
 
 import com.ceos.beatbuddy.domain.event.entity.Event;
 import com.ceos.beatbuddy.domain.event.entity.EventAttendance;
+import com.ceos.beatbuddy.domain.event.constant.SNSType;
 import com.ceos.beatbuddy.domain.member.constant.Gender;
 import com.ceos.beatbuddy.domain.member.entity.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -21,7 +22,7 @@ public class EventAttendanceRequestDTO {
     private String phoneNumber;
     private Integer totalNumber;
     private Boolean isPaid;
-    private String snsType;
+    private String snsType; // String으로 받아서 enum으로 변환
     private String snsId;
 
     public static EventAttendance toEntity(EventAttendanceRequestDTO dto, Member member, Event event) {
@@ -33,10 +34,13 @@ public class EventAttendanceRequestDTO {
         if (dto.getGender() != null) builder.gender(Gender.fromText(dto.getGender()));
         if (dto.getPhoneNumber() != null) builder.phoneNumber(dto.getPhoneNumber());
         if (dto.getTotalNumber() != null) builder.totalMember(dto.getTotalNumber());
-        if (dto.getSnsType() != null) builder.snsType(dto.getSnsType());
+        
+        // String을 SNSType enum으로 변환
+        SNSType snsType = SNSType.fromString(dto.getSnsType());
+        builder.snsType(snsType);
         
         // SNSType이 NONE인 경우 snsId는 항상 null로 처리
-        if ("NONE".equalsIgnoreCase(dto.getSnsType())) {
+        if (snsType.isNone()) {
             builder.snsId(null);
         } else if (dto.getSnsId() != null) {
             builder.snsId(dto.getSnsId());

--- a/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventAttendanceRequestDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventAttendanceRequestDTO.java
@@ -34,7 +34,14 @@ public class EventAttendanceRequestDTO {
         if (dto.getPhoneNumber() != null) builder.phoneNumber(dto.getPhoneNumber());
         if (dto.getTotalNumber() != null) builder.totalMember(dto.getTotalNumber());
         if (dto.getSnsType() != null) builder.snsType(dto.getSnsType());
-        if (dto.getSnsId() != null) builder.snsId(dto.getSnsId());
+        
+        // SNSType이 NONE인 경우 snsId는 항상 null로 처리
+        if ("NONE".equalsIgnoreCase(dto.getSnsType())) {
+            builder.snsId(null);
+        } else if (dto.getSnsId() != null) {
+            builder.snsId(dto.getSnsId());
+        }
+        
         builder.hasPaid(dto.getIsPaid());
 
         return builder.build();

--- a/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventAttendanceRequestDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventAttendanceRequestDTO.java
@@ -15,14 +15,21 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "이벤트 참석 요청 DTO")
 public class EventAttendanceRequestDTO {
+    @Schema(description = "이벤트 ID", example = "1")
     private String name;
-    @Schema(description = "성별 (MALE, FEMALE, None)")
+    @Schema(description = "성별 (MALE, FEMALE, None)", example = "MALE", allowableValues = "MALE, FEMALE, NONE")
     private String gender;
+    @Schema(description = "전화번호", example = "010-1234-5678")
     private String phoneNumber;
+    @Schema(description = "동행인원 (본인 포함)", example = "2")
     private Integer totalNumber;
+    @Schema(description = "결제 여부", example = "true")
     private Boolean isPaid;
+    @Schema(description = "SNS 타입 (INSTAGRAM, FACEBOOK, NONE 등)", example = "FACEBOOK", allowableValues = "INSTAGRAM, FACEBOOK, NONE")
     private String snsType; // String으로 받아서 enum으로 변환
+    @Schema(description = "SNS ID", example = "FACEBOOK123")
     private String snsId;
 
     public static EventAttendance toEntity(EventAttendanceRequestDTO dto, Member member, Event event) {

--- a/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventAttendanceResponseDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventAttendanceResponseDTO.java
@@ -31,7 +31,7 @@ public class EventAttendanceResponseDTO {
                 .name(entity.getName())
                 .gender(entity.getGender() != null ? entity.getGender().getText() : null)
                 .phoneNumber(entity.getPhoneNumber())
-                .snsType(entity.getSnsType())
+                .snsType(entity.getSnsType() != null ? entity.getSnsType().name() : null)
                 .snsId(entity.getSnsId())
                 .isPaid(entity.getHasPaid())
                 .totalMember(entity.getTotalMember())

--- a/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventAttendanceUpdateDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventAttendanceUpdateDTO.java
@@ -1,5 +1,6 @@
 package com.ceos.beatbuddy.domain.event.dto;
 
+import com.ceos.beatbuddy.domain.event.constant.SNSType;
 import com.ceos.beatbuddy.domain.member.constant.Gender;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,7 +21,7 @@ public class EventAttendanceUpdateDTO {
 
     private Integer totalMember; // 동행 인원
 
-    private String snsType;
+    private SNSType snsType;
 
     private String snsId;
 

--- a/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventResponseDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventResponseDTO.java
@@ -38,7 +38,7 @@ public class EventResponseDTO {
     private Boolean receiveName; // 이름 받을 건지
     private Boolean receiveGender; // 성별 받을 건지
     private Boolean receivePhoneNumber; // 전화번호 받을 건지
-    private Boolean receiveTotalCount; // 동행 인원 받을 건지
+    private Boolean receiveAccompany; // 동행 인원 받을 건지
     private Boolean receiveSNSId; // sns id 받을 건지
     private Boolean receiveMoney; // 예약금 받을 건지
 
@@ -93,6 +93,7 @@ public class EventResponseDTO {
                 .receiveName(event.isReceiveName())
                 .receiveGender(event.isReceiveGender())
                 .receivePhoneNumber(event.isReceivePhoneNumber())
+                .receiveAccompany(event.isReceiveTotalCount())
                 .receiveMoney(event.isReceiveMoney())
                 .receiveSNSId(event.isReceiveSNSId())
                 .depositAccount(Optional.ofNullable(event.getDepositAccount()).orElse(""))
@@ -122,6 +123,7 @@ public class EventResponseDTO {
                 .liked(liked)
                 .isAttending(isAttending)
                 .isFreeEntrance(event.isFreeEntrance())
+                .receiveAccompany(event.isReceiveTotalCount())
                 .region(Optional.ofNullable(event.getRegion()).map(Enum::name).orElse(""))
                 .build();
     }

--- a/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventResponseDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/dto/EventResponseDTO.java
@@ -124,7 +124,7 @@ public class EventResponseDTO {
                 .isAttending(isAttending)
                 .isFreeEntrance(event.isFreeEntrance())
                 .receiveAccompany(event.isReceiveTotalCount())
-                .region(Optional.ofNullable(event.getRegion()).map(Enum::name).orElse(""))
+                .region(Optional.of(event.getRegion().name()).orElse(""))
                 .build();
     }
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/event/entity/EventAttendance.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/entity/EventAttendance.java
@@ -57,7 +57,14 @@ public class EventAttendance extends BaseTimeEntity {
         Optional.ofNullable(dto.getPhoneNumber()).ifPresent(this::setPhoneNumber);
         Optional.ofNullable(dto.getTotalMember()).ifPresent(this::setTotalMember);
         Optional.ofNullable(dto.getSnsType()).ifPresent(this::setSnsType);
-        Optional.ofNullable(dto.getSnsId()).ifPresent(this::setSnsId);
+        
+        // SNSType이 NONE인 경우 snsId는 항상 null로 처리
+        if ("NONE".equalsIgnoreCase(dto.getSnsType())) {
+            this.setSnsId(null);
+        } else {
+            Optional.ofNullable(dto.getSnsId()).ifPresent(this::setSnsId);
+        }
+        
         Optional.ofNullable(dto.getHasPaid()).ifPresent(this::setHasPaid);
     }
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/event/entity/EventAttendance.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/entity/EventAttendance.java
@@ -1,6 +1,7 @@
 package com.ceos.beatbuddy.domain.event.entity;
 
 import com.ceos.beatbuddy.domain.event.dto.EventAttendanceUpdateDTO;
+import com.ceos.beatbuddy.domain.event.constant.SNSType;
 import com.ceos.beatbuddy.domain.member.constant.Gender;
 import com.ceos.beatbuddy.domain.member.entity.Member;
 import com.ceos.beatbuddy.global.BaseTimeEntity;
@@ -44,7 +45,8 @@ public class EventAttendance extends BaseTimeEntity {
     private Integer totalMember; // 동행인원 (본인 포함)
 
     @Setter(AccessLevel.PROTECTED)
-    private String snsType; // 인스타그램, 페이스북, X
+    @Enumerated(EnumType.STRING)
+    private SNSType snsType;
     @Setter(AccessLevel.PROTECTED)
     private String snsId;
 
@@ -59,7 +61,7 @@ public class EventAttendance extends BaseTimeEntity {
         Optional.ofNullable(dto.getSnsType()).ifPresent(this::setSnsType);
         
         // SNSType이 NONE인 경우 snsId는 항상 null로 처리
-        if ("NONE".equalsIgnoreCase(dto.getSnsType())) {
+        if (dto.getSnsType() != null && dto.getSnsType().isNone()) {
             this.setSnsId(null);
         } else {
             Optional.ofNullable(dto.getSnsId()).ifPresent(this::setSnsId);

--- a/src/main/java/com/ceos/beatbuddy/domain/event/exception/EventErrorCode.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/exception/EventErrorCode.java
@@ -22,7 +22,8 @@ public enum EventErrorCode implements ApiCode {
     REGION_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 지역입니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작 날짜가 종료 날짜보다 늦을 수 없습니다."),
     MISSING_DATE(HttpStatus.BAD_REQUEST, "시작 날짜와 종료 날짜는 필수입니다."),
-    PAST_EVENT_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "과거 이벤트는 허용되지 않습니다.");
+    PAST_EVENT_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "과거 이벤트는 허용되지 않습니다."),
+    SNS_TYPE_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 SNS 타입입니다.");
     private final HttpStatus httpStatus;
     private final String message;
 


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #368

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers
This PR introduces SNS type validation and handling improvements for event attendance functionality. The main purpose is to replace the string-based SNS type with a proper enum and implement special handling for "NONE" SNS type scenarios.

Key changes:

- Introduction of SNSType enum with proper validation and error handling
- Implementation of special logic for NONE SNS type where snsId should be null
- Updated field naming from receiveTotalCount to receiveAccompany for better clarity

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->