### PR TITLE
[Feat/#391] board hide blocked posts

### DIFF
--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/FreePostHandler.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/FreePostHandler.java
@@ -168,6 +168,28 @@ public class FreePostHandler implements PostTypeHandler{
     }
 
 
+    @Override
+    public Page<? extends Post> readAllPostsExcludingBlocked(Pageable pageable, List<Long> blockedMemberIds) {
+        return postQueryRepository.findAllFreePostsExcludingBlocked(pageable, blockedMemberIds);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PostListResponseDTO hashTagPostListExcludingBlocked(List<String> hashtags, Pageable pageable, Member member, List<Long> blockedMemberIds) {
+        if (hashtags == null || hashtags.isEmpty()) {
+            throw new CustomException(PostErrorCode.NOT_FOUND_HASHTAG);
+        }
+
+        // 해시태그 유효성 검사 및 변환
+        List<FixedHashtag> fixedHashtags = validateAndGetHashtags(hashtags);
+
+        // 차단된 사용자를 제외하고 조회
+        Page<FreePost> postPage = postQueryRepository.findPostsByHashtagsExcludingBlocked(
+                fixedHashtags, pageable, blockedMemberIds);
+
+        return postResponseHelper.createPostListResponse(postPage, member.getId());
+    }
+
     protected List<FixedHashtag> validateAndGetHashtags(List<String> hashtags) {
         if (hashtags == null || hashtags.isEmpty()) {
             return List.of();

--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/PiecePostHandler.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/PiecePostHandler.java
@@ -89,4 +89,15 @@ public class PiecePostHandler implements PostTypeHandler {
     public Page<? extends Post> readAllPostsByMember(Long memberId, Pageable pageable) {
         throw new UnsupportedOperationException("PiecePost 기능이 아직 구현되지 않았습니다.");
     }
+
+    @Override
+    public Page<? extends Post> readAllPostsExcludingBlocked(Pageable pageable, List<Long> blockedMemberIds) {
+        // PiecePost는 아직 구현되지 않았으므로 기본 조회 반환
+        return piecePostRepository.findAll(pageable);
+    }
+
+    @Override
+    public PostListResponseDTO hashTagPostListExcludingBlocked(List<String> hashtags, Pageable pageable, Member member, List<Long> blockedMemberIds) {
+        throw new UnsupportedOperationException("PiecePost 생성 기능이 아직 구현되지 않았습니다.");
+    }
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/PostResponseHelper.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/PostResponseHelper.java
@@ -42,30 +42,6 @@ public class PostResponseHelper {
                 .build();
     }
 
-    public PostListResponseDTO createPostListResponseExcludingBlocked(Page<? extends Post> postPage, Long memberId, Set<Long> blockedMemberIds) {
-        List<? extends Post> posts = postPage.getContent();
-        
-        // 차단한 사용자의 게시물 제외
-        List<? extends Post> filteredPosts = posts.stream()
-                .filter(post -> !blockedMemberIds.contains(post.getMember().getId()))
-                .toList();
-        
-        List<Long> postIds = filteredPosts.stream().map(Post::getId).toList();
-
-        PostInteractionStatus status = postInteractionService.getAllPostInteractions(memberId, postIds);
-        Set<Long> followingIds = followRepository.findFollowingMemberIds(memberId);
-
-        List<PostPageResponseDTO> dtoList = filteredPosts.stream()
-                .map(post -> createPostPageResponseDTO(post, status, memberId, followingIds))
-                .toList();
-
-        return PostListResponseDTO.builder()
-                .totalPost(filteredPosts.size())
-                .page(postPage.getNumber() + 1)
-                .size(postPage.getSize())
-                .responseDTOS(dtoList)
-                .build();
-    }
 
     public List<PostPageResponseDTO> createPostPageResponseDTOList(List<? extends Post> posts, Long memberId) {
         List<Long> postIds = posts.stream().map(Post::getId).toList();
@@ -78,21 +54,6 @@ public class PostResponseHelper {
                 .toList();
     }
 
-    public List<PostPageResponseDTO> createPostPageResponseDTOListExcludingBlocked(List<? extends Post> posts, Long memberId, Set<Long> blockedMemberIds) {
-        // 차단한 사용자의 게시물 제외
-        List<? extends Post> filteredPosts = posts.stream()
-                .filter(post -> !blockedMemberIds.contains(post.getMember().getId()))
-                .toList();
-        
-        List<Long> postIds = filteredPosts.stream().map(Post::getId).toList();
-        
-        PostInteractionStatus status = postInteractionService.getAllPostInteractions(memberId, postIds);
-        Set<Long> followingIds = followRepository.findFollowingMemberIds(memberId);
-
-        return filteredPosts.stream()
-                .map(post -> createPostPageResponseDTO(post, status, memberId, followingIds))
-                .toList();
-    }
 
     public PostPageResponseDTO createPostPageResponseDTO(Post post, PostInteractionStatus status, Long memberId, Set<Long> followingIds) {
         List<FixedHashtag> hashtags = getHashtagsForPost(post);

--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/PostResponseHelper.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/PostResponseHelper.java
@@ -42,6 +42,31 @@ public class PostResponseHelper {
                 .build();
     }
 
+    public PostListResponseDTO createPostListResponseExcludingBlocked(Page<? extends Post> postPage, Long memberId, Set<Long> blockedMemberIds) {
+        List<? extends Post> posts = postPage.getContent();
+        
+        // 차단한 사용자의 게시물 제외
+        List<? extends Post> filteredPosts = posts.stream()
+                .filter(post -> !blockedMemberIds.contains(post.getMember().getId()))
+                .toList();
+        
+        List<Long> postIds = filteredPosts.stream().map(Post::getId).toList();
+
+        PostInteractionStatus status = postInteractionService.getAllPostInteractions(memberId, postIds);
+        Set<Long> followingIds = followRepository.findFollowingMemberIds(memberId);
+
+        List<PostPageResponseDTO> dtoList = filteredPosts.stream()
+                .map(post -> createPostPageResponseDTO(post, status, memberId, followingIds))
+                .toList();
+
+        return PostListResponseDTO.builder()
+                .totalPost(filteredPosts.size())
+                .page(postPage.getNumber() + 1)
+                .size(postPage.getSize())
+                .responseDTOS(dtoList)
+                .build();
+    }
+
     public List<PostPageResponseDTO> createPostPageResponseDTOList(List<? extends Post> posts, Long memberId) {
         List<Long> postIds = posts.stream().map(Post::getId).toList();
         
@@ -49,6 +74,22 @@ public class PostResponseHelper {
         Set<Long> followingIds = followRepository.findFollowingMemberIds(memberId);
 
         return posts.stream()
+                .map(post -> createPostPageResponseDTO(post, status, memberId, followingIds))
+                .toList();
+    }
+
+    public List<PostPageResponseDTO> createPostPageResponseDTOListExcludingBlocked(List<? extends Post> posts, Long memberId, Set<Long> blockedMemberIds) {
+        // 차단한 사용자의 게시물 제외
+        List<? extends Post> filteredPosts = posts.stream()
+                .filter(post -> !blockedMemberIds.contains(post.getMember().getId()))
+                .toList();
+        
+        List<Long> postIds = filteredPosts.stream().map(Post::getId).toList();
+        
+        PostInteractionStatus status = postInteractionService.getAllPostInteractions(memberId, postIds);
+        Set<Long> followingIds = followRepository.findFollowingMemberIds(memberId);
+
+        return filteredPosts.stream()
                 .map(post -> createPostPageResponseDTO(post, status, memberId, followingIds))
                 .toList();
     }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/PostService.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/PostService.java
@@ -10,8 +10,6 @@ import com.ceos.beatbuddy.domain.post.entity.FreePost;
 import com.ceos.beatbuddy.domain.post.entity.Post;
 import com.ceos.beatbuddy.domain.post.exception.PostErrorCode;
 import com.ceos.beatbuddy.domain.post.repository.PostQueryRepository;
-import com.ceos.beatbuddy.domain.post.repository.PostRepository;
-import com.ceos.beatbuddy.domain.scrapandlike.repository.CommentLikeRepository;
 import com.ceos.beatbuddy.domain.scrapandlike.repository.PostLikeRepository;
 import com.ceos.beatbuddy.domain.scrapandlike.repository.PostScrapRepository;
 import com.ceos.beatbuddy.global.CustomException;
@@ -20,6 +18,7 @@ import com.ceos.beatbuddy.global.service.ImageUploadService;
 import com.ceos.beatbuddy.global.util.UploadResult;
 import com.ceos.beatbuddy.global.util.UploadUtil;
 import com.ceos.beatbuddy.global.util.UploadUtilAsyncWrapper;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Triple;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -35,48 +34,22 @@ import java.util.Set;
 
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class PostService {
     private final MemberService memberService;
     private final PostLikeRepository postLikeRepository;
     private final PostScrapRepository postScrapRepository;
     private final PostQueryRepository postQueryRepository;
     private final CommentRepository commentRepository;
-    private final CommentLikeRepository commentLikeRepository;
     private final PostTypeHandlerFactory postTypeHandlerFactory;
     private final ImageUploadService imageUploadService;
     private final UploadUtilAsyncWrapper uploadUtilAsyncWrapper;
-    private final PostRepository postRepository;
     private final PostInteractionService postInteractionService;
     private final FollowRepository followRepository;
-    private final UploadUtil uploadUtil;
     private final PostResponseHelper postResponseHelper;
     private final PostValidationHelper postValidationHelper;
 
     private static final List<String> VALID_POST_TYPES = List.of("free", "piece");
-
-    public PostService(MemberService memberService, PostLikeRepository postLikeRepository,
-                       PostScrapRepository postScrapRepository, PostQueryRepository postQueryRepository,
-                       CommentRepository commentRepository, CommentLikeRepository commentLikeRepository,
-                       PostTypeHandlerFactory postTypeHandlerFactory,
-                       ImageUploadService imageUploadService, UploadUtilAsyncWrapper uploadUtilAsyncWrapper,
-                       PostRepository postRepository, PostInteractionService postInteractionService,
-                       FollowRepository followRepository, UploadUtil uploadUtil, PostResponseHelper postResponseHelper, PostValidationHelper postValidationHelper) {
-        this.memberService = memberService;
-        this.postLikeRepository = postLikeRepository;
-        this.postScrapRepository = postScrapRepository;
-        this.postQueryRepository = postQueryRepository;
-        this.commentRepository = commentRepository;
-        this.commentLikeRepository = commentLikeRepository;
-        this.postTypeHandlerFactory = postTypeHandlerFactory;
-        this.imageUploadService = imageUploadService;
-        this.uploadUtilAsyncWrapper = uploadUtilAsyncWrapper;
-        this.postRepository = postRepository;
-        this.postInteractionService = postInteractionService;
-        this.followRepository = followRepository;
-        this.uploadUtil = uploadUtil;
-        this.postResponseHelper = postResponseHelper;
-        this.postValidationHelper = postValidationHelper;
-    }
 
     @Transactional
     public ResponsePostDto addNewPost(String type, PostCreateRequestDTO dto, Long memberId, List<MultipartFile> images) {

--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/PostTypeHandler.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/PostTypeHandler.java
@@ -66,4 +66,22 @@ public interface PostTypeHandler {
     Page<? extends Post> readAllPostsByUserExcludingAnonymous(Long userId, Pageable pageable);
 
     Page<? extends Post> readAllPostsByMember(Long memberId, Pageable pageable);
+
+    /**
+     * 모든 게시글을 페이지네이션으로 조회합니다 (차단된 사용자 제외).
+     * @param pageable 페이지네이션 정보
+     * @param blockedMemberIds 차단된 멤버 ID 목록
+     * @return 페이지네이션된 게시글 목록 (차단된 사용자 제외)
+     */
+    Page<? extends Post> readAllPostsExcludingBlocked(Pageable pageable, List<Long> blockedMemberIds);
+
+    /**
+     * 해시태그별 게시글을 조회합니다 (차단된 사용자 제외).
+     * @param hashtags 해시태그 목록
+     * @param pageable 페이지네이션 정보
+     * @param member 요청자
+     * @param blockedMemberIds 차단된 멤버 ID 목록
+     * @return 해시태그별 게시글 목록 (차단된 사용자 제외)
+     */
+    PostListResponseDTO hashTagPostListExcludingBlocked(List<String> hashtags, Pageable pageable, Member member, List<Long> blockedMemberIds);
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/dto/PostPageResponseDTO.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/dto/PostPageResponseDTO.java
@@ -84,8 +84,7 @@ public class PostPageResponseDTO {
                 .nickname(post.isAnonymous() 
                         ? "익명" 
                         : (post.getMember().getPostProfileInfo() != null && post.getMember().getPostProfileInfo().getPostProfileNickname() != null
-                                ? post.getMember().getPostProfileInfo().getPostProfileNickname()
-                                : post.getMember().getNickname()))
+                                ? post.getMember().getPostProfileInfo().getPostProfileNickname() : ""))
                 .createAt(post.getCreatedAt())
                 .likes(post.getLikes())
                 .scraps(post.getScraps())
@@ -104,10 +103,7 @@ public class PostPageResponseDTO {
                         post.isAnonymous()
                                 ? ""
                                 : (post.getMember().getPostProfileInfo() != null && post.getMember().getPostProfileInfo().getPostProfileImageUrl() != null
-                                ? post.getMember().getPostProfileInfo().getPostProfileImageUrl()
-                                : (post.getMember().getProfileImage() != null
-                                        ? post.getMember().getProfileImage()
-                                        : ""))
+                                ? post.getMember().getPostProfileInfo().getPostProfileImageUrl() : "")
                 )
                 .isFollowing(isFollowing)
                 .build();

--- a/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepository.java
@@ -30,4 +30,12 @@ public interface PostQueryRepository {
      * @return 포스트 페이지 (차단된 멤버 제외)
      */
     Page<FreePost> findPostsByHashtagsExcludingBlocked(List<FixedHashtag> hashtags, Pageable pageable, List<Long> blockedMemberIds);
+    
+    /**
+     * 모든 FreePost 조회 (차단된 멤버 제외)
+     * @param pageable 페이징 정보
+     * @param blockedMemberIds 차단된 멤버 ID 목록
+     * @return 포스트 페이지 (차단된 멤버 제외)
+     */
+    Page<FreePost> findAllFreePostsExcludingBlocked(Pageable pageable, List<Long> blockedMemberIds);
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/repository/PostQueryRepositoryImpl.java
@@ -136,4 +136,33 @@ public class PostQueryRepositoryImpl implements PostQueryRepository{
 
         return new PageImpl<>(content, pageable, count != null ? count : 0L);
     }
+
+    @Override
+    public Page<FreePost> findAllFreePostsExcludingBlocked(Pageable pageable, List<Long> blockedMemberIds) {
+        QFreePost freePost = QFreePost.freePost;
+
+        // where 조건 설정
+        BooleanExpression whereCondition = null;
+        if (!blockedMemberIds.isEmpty()) {
+            whereCondition = freePost.member.id.notIn(blockedMemberIds);
+        }
+
+        // 데이터 조회
+        List<FreePost> content = queryFactory
+                .selectFrom(freePost)
+                .where(whereCondition)
+                .orderBy(freePost.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 개수 조회
+        Long count = queryFactory
+                .select(freePost.count())
+                .from(freePost)
+                .where(whereCondition)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, count != null ? count : 0);
+    }
 }


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #391

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers
This PR implements functionality to hide blocked posts from the board view, preventing users from seeing content from members they have blocked. The implementation includes adding new repository methods, service integration, and updating the PostPageResponseDTO to handle fallback values more consistently.

- Add repository methods to exclude blocked members from post queries
- Integrate blocked member filtering into post retrieval services
- Refactor constructor injection to use Lombok's @requiredargsconstructor
- Simplify fallback logic for user profile information in DTOs

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->