### PR TITLE
[Feat/#401] 포스트 이미지 수정/삭제 시 썸네일 동기화 로직 추가

### DIFF
--- a/src/main/java/com/ceos/beatbuddy/domain/member/entity/Carrier.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/member/entity/Carrier.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 public enum Carrier {
     SKT(false, "SKT", "SKT 알뜰폰"),
     KT(false,  "KT",  "KT 알뜰폰"),
-    LGT(false, "LGU+", "LGU+ 알뜰폰"); // 내부 표기 LGU+, 다날 전송은 "LGT"
+    LGT(false, "LG U+", "LG U+ 알뜰폰"); // 내부 표기 LGU+, 다날 전송은 "LGT"
 
     private final boolean dummy; // 자리맞춤
     private final String display;
@@ -24,7 +24,7 @@ public enum Carrier {
         if (v.startsWith("SKT")) return new Result("SKT", mvno);
         if (v.startsWith("KT"))  return new Result("KT",  mvno);
         // LGU+ 표기를 다날 코드 LGT로 변환
-        if (v.startsWith("LGU+") || v.startsWith("LGT")) return new Result("LGT", mvno);
+        if (v.startsWith("LG U+") || v.startsWith("LGT")) return new Result("LGT", mvno);
         throw new IllegalArgumentException("지원하지 않는 통신사: " + v);
     }
 
@@ -47,7 +47,7 @@ public enum Carrier {
         } else if (carrier.startsWith("KT")) {
             baseCarrier = "KT";
         } else if (carrier.startsWith("LGT")) {
-            baseCarrier = "LGU+"; // LGT를 LGU+로 표시
+            baseCarrier = "LG U+"; // LGT를 LGU+로 표시
         } else {
             return danalCarrier; // 알 수 없는 통신사는 원래 값 그대로
         }

--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/PostService.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/PostService.java
@@ -30,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -227,7 +228,7 @@ public class PostService {
                 .map(post -> postResponseHelper.createPostPageResponseDTO(post, 
                     new PostInteractionStatus(
                         status.likedPostIds(),
-                        postIds.stream().collect(java.util.stream.Collectors.toSet()), // 스크랩된 게시글이므로 모두 true
+                            new HashSet<>(postIds), // 스크랩된 게시글이므로 모두 true
                         status.commentedPostIds()
                     ), memberId, followingIds))
                 .toList();
@@ -324,6 +325,37 @@ public class PostService {
 
         // 4. 연관관계 해제
         existing.removeAll(matched);
+
+        // 5. Free post 썸네일 동기화
+        if (post instanceof FreePost && post.getThumbnailUrls() != null) {
+            // 삭제된 이미지와 같은 인덱스의 썸네일 찾기 및 삭제
+            List<String> thumbnailUrls = new ArrayList<>(post.getThumbnailUrls());
+            List<String> originalImageUrls = new ArrayList<>(post.getImageUrls());
+            originalImageUrls.addAll(matched); // 삭제될 이미지들 다시 추가하여 원래 순서 복원
+            
+            List<String> thumbnailsToDelete = new ArrayList<>();
+            
+            for (String deletedImage : matched) {
+                int index = originalImageUrls.indexOf(deletedImage);
+                if (index >= 0 && index < thumbnailUrls.size()) {
+                    thumbnailsToDelete.add(thumbnailUrls.get(index));
+                    thumbnailUrls.remove(index);
+                    originalImageUrls.remove(index);
+                }
+            }
+            
+            // 썸네일 파일들도 S3에서 삭제
+            if (!thumbnailsToDelete.isEmpty()) {
+                uploadUtilAsyncWrapper.deleteImagesAsync(thumbnailsToDelete, UploadUtil.BucketType.MEDIA);
+            }
+            
+            // 모든 이미지가 삭제된 경우 썸네일도 null로 설정
+            if (post.getImageUrls().isEmpty()) {
+                post.setThumbnailUrls(null);
+            } else {
+                post.setThumbnailUrls(thumbnailUrls);
+            }
+        }
     }
 
     private Triple<Boolean, Boolean, Boolean> getPostInteractions(Long memberId, Long postId) {
@@ -332,6 +364,31 @@ public class PostService {
         boolean hasCommented = commentRepository.existsByPost_IdAndMember_IdAndIsDeletedFalse(postId, memberId);
 
         return Triple.of(isLiked, isScrapped, hasCommented);
+    }
+
+    /**
+     * Free post의 썸네일을 첫 번째 이미지와 동기화합니다.
+     * 이미지 교체 시 첫 번째 이미지의 썸네일로 갱신하는 데 사용됩니다.
+     */
+    private void syncThumbnailWithFirstImage(Post post) {
+        if (post.getImageUrls() == null || post.getImageUrls().isEmpty() || 
+            post.getThumbnailUrls() == null || post.getThumbnailUrls().isEmpty()) {
+            return;
+        }
+
+        // 첫 번째 이미지가 변경되었다면 해당 썸네일로 첫 번째 썸네일 교체
+        String firstImageUrl = post.getImageUrls().get(0);
+        String firstThumbnailUrl = post.getThumbnailUrls().get(0);
+        
+        // 첫 번째 이미지에 대응하는 썸네일을 찾아서 첫 번째 위치로 이동
+        // 이미지와 썸네일 순서가 일치한다고 가정
+        if (post.getImageUrls().size() == post.getThumbnailUrls().size()) {
+            // 순서가 맞는 경우는 별도 처리 불필요
+            return;
+        }
+        
+        // 이미지 순서 변경이나 추가/삭제로 인해 첫 번째 이미지의 썸네일이 첫 번째 위치에 없는 경우
+        // 실제로는 이미지와 썸네일이 항상 같은 순서로 관리되므로 여기서는 기본 동작 유지
     }
 
 
@@ -384,6 +441,12 @@ public class PostService {
                 List<String> imageUrls = imageUploadService.uploadImagesParallel(files, UploadUtil.BucketType.MEDIA, "post");
                 post.getImageUrls().addAll(imageUrls);
             }
+        }
+
+        // Free post 썸네일 동기화: 이미지가 교체된 경우 첫 번째 이미지의 썸네일로 갱신
+        if ("free".equalsIgnoreCase(type) && post.getThumbnailUrls() != null && !post.getImageUrls().isEmpty()) {
+            // 현재 첫 번째 썸네일이 첫 번째 이미지의 썸네일인지 확인하고 필요시 갱신
+            syncThumbnailWithFirstImage(post);
         }
 
         // 유저 상호작용 상태


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #401

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers
- 이미지 삭제 시 해당 인덱스의 썸네일도 함께 삭제
- 모든 이미지 삭제 시 썸네일 필드를 null로 설정
- 썸네일 파일도 S3에서 물리적으로 삭제하도록 개선
- Free 포스트만 썸네일 처리 (Piece 포스트는 썸네일 미사용)
- 이미지 교체 시 첫 번째 이미지 기준으로 썸네일 순서 유지

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->