### PR TITLE
[Fix/#404] thumbnail sync after image update

### DIFF
--- a/src/main/java/com/ceos/beatbuddy/domain/post/application/PostService.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/post/application/PostService.java
@@ -310,23 +310,30 @@ public class PostService {
     public void removeImages(Post post, List<String> deleteFiles) {
         List<String> existing = post.getImageUrls();
 
-        // 1. 삭제 대상 필터링
-        List<String> matched = existing.stream()
-                .filter(deleteFiles::contains)
-                .toList();
+        // 1. CloudFront URL을 S3 URL로 변환 (필요한 경우)
+        List<String> normalizedDeleteFiles = normalizeUrlsForComparison(deleteFiles);
+        List<String> normalizedExisting = normalizeUrlsForComparison(existing);
 
-        // 2. 유효성 검증
+        // 2. 삭제 대상 필터링 - 정규화된 URL로 비교
+        List<String> matched = new ArrayList<>();
+        for (int i = 0; i < existing.size(); i++) {
+            if (normalizedDeleteFiles.contains(normalizedExisting.get(i))) {
+                matched.add(existing.get(i)); // 원본 URL 사용
+            }
+        }
+
+        // 3. 유효성 검증
         if (matched.size() != deleteFiles.size()) {
             throw new CustomException(PostErrorCode.FILE_NOT_FOUND);
         }
 
-        // 3. S3 삭제
-        uploadUtilAsyncWrapper.deleteImagesAsync(deleteFiles, UploadUtil.BucketType.MEDIA);
+        // 4. S3 삭제 - 실제 S3 URL(matched)로 삭제
+        uploadUtilAsyncWrapper.deleteImagesAsync(matched, UploadUtil.BucketType.MEDIA);
 
-        // 4. 연관관계 해제
+        // 5. 연관관계 해제
         existing.removeAll(matched);
 
-        // 5. Free post 썸네일 동기화
+        // 6. Free post 썸네일 동기화
         if (post instanceof FreePost && post.getThumbnailUrls() != null) {
             List<String> thumbnailUrls = new ArrayList<>(post.getThumbnailUrls());
             List<String> originalImageUrls = new ArrayList<>(post.getImageUrls());
@@ -377,7 +384,65 @@ public class PostService {
         return Triple.of(isLiked, isScrapped, hasCommented);
     }
 
+    /**
+     * Free Post의 썸네일과 이미지 순서 동기화
+     * 이미지 개수와 썸네일 개수가 다른 경우 썸네일을 null로 설정
+     */
+    private void synchronizeFrePostThumbnails(Post post) {
+        if (!(post instanceof FreePost)) {
+            return;
+        }
+        
+        List<String> imageUrls = post.getImageUrls();
+        List<String> thumbnailUrls = post.getThumbnailUrls();
+        
+        // 이미지와 썸네일 개수가 다른 경우
+        if (imageUrls.size() != thumbnailUrls.size()) {
+            // 썸네일을 null로 설정하여 불일치 방지
+            post.setThumbnailUrls(null);
+            
+            // 필요시 기존 썸네일들을 S3에서 삭제 (선택적)
+            if (!thumbnailUrls.isEmpty()) {
+                uploadUtilAsyncWrapper.deleteImagesAsync(thumbnailUrls, UploadUtil.BucketType.MEDIA);
+            }
+        }
+    }
 
+    /**
+     * URL 비교를 위한 정규화 처리
+     * CloudFront URL과 S3 URL을 모두 동일한 형태로 변환하여 비교 가능하게 함
+     */
+    private List<String> normalizeUrlsForComparison(List<String> urls) {
+        return urls.stream()
+                .map(this::normalizeUrlForComparison)
+                .toList();
+    }
+    
+    /**
+     * 단일 URL 정규화 처리
+     * URL에서 도메인 부분을 제거하고 경로만 추출하여 비교
+     */
+    private String normalizeUrlForComparison(String url) {
+        if (url == null || url.isEmpty()) {
+            return url;
+        }
+        
+        // URL에서 경로 부분만 추출 (도메인 제거)
+        // 예: https://cloudfront.amazonaws.com/path/to/file.jpg -> /path/to/file.jpg
+        // 또는 https://s3.amazonaws.com/bucket/path/to/file.jpg -> /path/to/file.jpg
+        try {
+            if (url.startsWith("http://") || url.startsWith("https://")) {
+                int thirdSlashIndex = url.indexOf('/', url.indexOf("://") + 3);
+                if (thirdSlashIndex > 0) {
+                    return url.substring(thirdSlashIndex);
+                }
+            }
+            return url;
+        } catch (Exception e) {
+            // URL 파싱 실패 시 원본 반환
+            return url;
+        }
+    }
 
     @Transactional
     public PostReadDetailDTO updatePost(String type, Long postId, Long memberId,
@@ -430,7 +495,10 @@ public class PostService {
             }
         }
 
-        // Free post 썸네일은 이미지와 동일한 순서로 관리되므로 별도 동기화 불필요
+        // Free post 썸네일 동기화 - 이미지와 썸네일 순서 일치 보장
+        if ("free".equalsIgnoreCase(type) && post.getThumbnailUrls() != null) {
+            synchronizeFrePostThumbnails(post);
+        }
 
         // 유저 상호작용 상태
         Triple<Boolean, Boolean, Boolean> status = getPostInteractions(memberId, postId);

--- a/src/main/java/com/ceos/beatbuddy/global/util/UploadUtil.java
+++ b/src/main/java/com/ceos/beatbuddy/global/util/UploadUtil.java
@@ -327,8 +327,8 @@ public class UploadUtil {
             // URL 파싱 실패 시 원본에서 도메인 제거 시도
         }
         
-        // 마지막으로 전체 URL에서 bucket URL 제거 시도
-        return imageUrl.replace(s3BucketUrl, "");
+        // 유효한 S3 key를 추출할 수 없는 경우 빈 문자열 반환
+        return "";
     }
 
     public void deleteImages(List<String> imageUrls, BucketType type) {

--- a/src/main/java/com/ceos/beatbuddy/global/util/UploadUtil.java
+++ b/src/main/java/com/ceos/beatbuddy/global/util/UploadUtil.java
@@ -286,14 +286,49 @@ public class UploadUtil {
         if (imageUrl == null || imageUrl.isBlank()) return;
 
         String bucketName = getBucketName(type);
-        String bucketUrl = "https://" + bucketName + ".s3." + region + ".amazonaws.com/";
-        String key = imageUrl.replace(bucketUrl, "");
+        String key = extractS3KeyFromUrl(imageUrl, bucketName);
 
         try {
             amazonS3.deleteObject(bucketName, key);
         } catch (Exception e) {
             throw new CustomException(ErrorCode.IMAGE_DELETE_FAILED);
         }
+    }
+    
+    /**
+     * URL에서 S3 key를 추출합니다. CloudFront URL과 S3 URL 모두 지원합니다.
+     * 
+     * @param imageUrl S3 또는 CloudFront URL
+     * @param bucketName S3 버킷 이름
+     * @return S3 객체 key
+     */
+    private String extractS3KeyFromUrl(String imageUrl, String bucketName) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return "";
+        }
+        
+        // S3 URL 형태인 경우: https://bucketname.s3.region.amazonaws.com/path/to/file.jpg
+        String s3BucketUrl = "https://" + bucketName + ".s3." + region + ".amazonaws.com/";
+        if (imageUrl.startsWith(s3BucketUrl)) {
+            return imageUrl.replace(s3BucketUrl, "");
+        }
+        
+        // CloudFront URL 형태인 경우: https://cloudfront-domain.com/path/to/file.jpg
+        // URL에서 경로 부분만 추출 (도메인 제거)
+        try {
+            if (imageUrl.startsWith("http://") || imageUrl.startsWith("https://")) {
+                int thirdSlashIndex = imageUrl.indexOf('/', imageUrl.indexOf("://") + 3);
+                if (thirdSlashIndex > 0) {
+                    String path = imageUrl.substring(thirdSlashIndex + 1); // 앞의 '/' 제거
+                    return path;
+                }
+            }
+        } catch (Exception e) {
+            // URL 파싱 실패 시 원본에서 도메인 제거 시도
+        }
+        
+        // 마지막으로 전체 URL에서 bucket URL 제거 시도
+        return imageUrl.replace(s3BucketUrl, "");
     }
 
     public void deleteImages(List<String> imageUrls, BucketType type) {


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #404

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [x]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers
This PR fixes thumbnail synchronization issues after image updates by improving URL comparison logic to handle both CloudFront and S3 URLs, and adding proper thumbnail synchronization for Free posts.

- Refactored URL handling to support both CloudFront and S3 URL formats
- Enhanced image deletion logic with URL normalization for accurate comparison
- Added thumbnail synchronization mechanism for Free posts to prevent mismatches

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->