### PR TITLE
[Fix/#434] 이벤트 인기순 정렬 및 스케줄러 로직 개선

### DIFF
--- a/src/main/java/com/ceos/beatbuddy/domain/event/repository/EventQueryRepositoryImpl.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/repository/EventQueryRepositoryImpl.java
@@ -37,18 +37,15 @@ public class EventQueryRepositoryImpl implements EventQueryRepository {
                 .and(event.isVisible.eq(true));
 
         if ("popular".equals(sort)) {
-            LocalDateTime now = LocalDateTime.now();
-            LocalDateTime yesterday = now.minusDays(1);
-
             return queryFactory
                     .select(event)
                     .from(event)
                     .leftJoin(event.venue, QVenue.venue).fetchJoin()
-                    .leftJoin(eventLike).on(eventLike.event.eq(event).and(eventLike.createdAt.between(yesterday, now)))
+                    .leftJoin(eventLike).on(eventLike.event.eq(event))
                     .where(builder)
                     .groupBy(event)
                     .orderBy(
-                            eventLike.count().desc(), // 1순위: 좋아요 개수 많은 순
+                            eventLike.count().desc(), // 1순위: 전체 좋아요 개수 많은 순
                             event.startDate.asc()     // 2순위: 시작일 빠른 순
                     )
                     .offset(offset)

--- a/src/main/java/com/ceos/beatbuddy/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/repository/EventRepository.java
@@ -38,36 +38,36 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     int countAllByVenue_Id(Long venueId);
 
-    // 오늘 시작 이전이면 이미 과거로 간 것: NOW → PAST
+    // 종료시간이 현재 시간보다 이전이면 과거로 변경: NOW → PAST
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
         update Event e
            set e.status = 'PAST'
          where e.status = 'NOW'
-           and e.endDate < :startOfToday
+           and e.endDate < :now
     """)
-    int updateToPast(@Param("startOfToday") LocalDateTime startOfToday);
+    int updateToPast(@Param("now") LocalDateTime now);
 
-    // 현재 날짜가 이벤트 기간 내에 있으면: UPCOMING → NOW
+    // 현재 시간이 이벤트 기간 내에 있으면: UPCOMING → NOW
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
         update Event e
            set e.status = 'NOW'
          where e.status = 'UPCOMING'
-           and e.startDate <= :startOfToday
-           and e.endDate   >= :startOfToday
+           and e.startDate <= :now
+           and e.endDate   >= :now
     """)
-    int updateToNow(@Param("startOfToday") LocalDateTime startOfToday);
+    int updateToNow(@Param("now") LocalDateTime now);
 
-    // 종료일이 오늘 시작보다 이전이면: UPCOMING → PAST (이상치 정리)
+    // 종료시간이 현재 시간보다 이전이면: UPCOMING → PAST (이상치 정리)
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
         update Event e
            set e.status = 'PAST'
          where e.status = 'UPCOMING'
-           and e.endDate < :startOfToday
+           and e.endDate < :now
     """)
-    int updateUpcomingToPast(@Param("startOfToday") LocalDateTime startOfToday);
+    int updateUpcomingToPast(@Param("now") LocalDateTime now);
     // 동시성 제어를 위한 PESSIMISTIC_WRITE 락
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT e FROM Event e WHERE e.id = :id")

--- a/src/main/java/com/ceos/beatbuddy/domain/event/scheduler/EventStatusScheduler.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/event/scheduler/EventStatusScheduler.java
@@ -18,23 +18,21 @@ public class EventStatusScheduler {
 
     private final EventRepository eventRepository;
 
-    @Scheduled(cron = "0 0 * * * *", zone ="Asia/Seoul") // 매 정시, 시간 무시해도 안정적으로 정렬됨
+    @Scheduled(cron = "0 0 * * * *", zone ="Asia/Seoul") // 매 정시
     @Transactional
     public void updateEventStatusesSafely() {
         try {
-            LocalDate today = LocalDate.now();
-            LocalDateTime startOfToday = today.atStartOfDay();          // 00:00:00
-            LocalDateTime endOfToday   = today.atTime(LocalTime.MAX);   // 23:59:59.999...
+            LocalDateTime now = LocalDateTime.now();
 
-            log.info("🔄 이벤트 상태 업데이트 시작: today={}, start={}, end={}", today, startOfToday, endOfToday);
+            log.info("🔄 이벤트 상태 업데이트 시작: 현재시간={}", now);
 
-            int nowUpdated = eventRepository.updateToNow(startOfToday);
+            int nowUpdated = eventRepository.updateToNow(now);
             log.info("📍 UPCOMING -> NOW 업데이트: {}건", nowUpdated);
 
-            int pastUpdated = eventRepository.updateToPast(startOfToday);
+            int pastUpdated = eventRepository.updateToPast(now);
             log.info("📍 NOW -> PAST 업데이트: {}건", pastUpdated);
 
-            int directPastUpdated = eventRepository.updateUpcomingToPast(startOfToday);
+            int directPastUpdated = eventRepository.updateUpcomingToPast(now);
             log.info("📍 UPCOMING -> PAST 직접 업데이트: {}건", directPastUpdated);
 
             log.info("✅ 이벤트 상태 업데이트 완료 - 총 {}건 처리",
@@ -51,24 +49,22 @@ public class EventStatusScheduler {
     @Transactional
     public void runManually() {
         try {
-            LocalDate today = LocalDate.now();
-            LocalDateTime startOfToday = today.atStartOfDay();          // 00:00:00
-            LocalDateTime endOfToday   = today.atTime(LocalTime.MAX);   // 23:59:59.999...
-            log.info("🔧 수동 이벤트 상태 업데이트 실행: {}", today);
+            LocalDateTime now = LocalDateTime.now();
+            log.info("🔧 수동 이벤트 상태 업데이트 실행: 현재시간={}", now);
 
             // 1. UPCOMING -> NOW 상태 업데이트
-            int nowUpdated = eventRepository.updateToNow(startOfToday);
+            int nowUpdated = eventRepository.updateToNow(now);
             log.info("📍 UPCOMING -> NOW 업데이트: {}건", nowUpdated);
 
-            // 2. NOW -> PAST 상태 업데이트  
-            int pastUpdated = eventRepository.updateToPast(startOfToday);
+            // 2. NOW -> PAST 상태 업데이트
+            int pastUpdated = eventRepository.updateToPast(now);
             log.info("📍 NOW -> PAST 업데이트: {}건", pastUpdated);
 
             // 3. UPCOMING -> PAST 직접 업데이트 (종료시간이 지난 UPCOMING 이벤트)
-            int directPastUpdated = eventRepository.updateUpcomingToPast(startOfToday);
+            int directPastUpdated = eventRepository.updateUpcomingToPast(now);
             log.info("📍 UPCOMING -> PAST 직접 업데이트: {}건", directPastUpdated);
 
-            log.info("✅ 수동 이벤트 상태 업데이트 완료 - 총 {}건 처리", 
+            log.info("✅ 수동 이벤트 상태 업데이트 완료 - 총 {}건 처리",
                     nowUpdated + pastUpdated + directPastUpdated);
         } catch (Exception e) {
             log.error("❌ 수동 이벤트 상태 업데이트 실패", e);


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [x]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers
- 인기순 정렬: 최근 1일 제한 제거하여 전체 좋아요 수 기준으로 변경
- 스케줄러: startOfToday 대신 현재 시간(LocalDateTime.now()) 기준으로 정확한 상태 업데이트

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->