### PR TITLE
[FEAT#437] 로그아웃, 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/ceos/beatbuddy/domain/member/application/MemberService.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/member/application/MemberService.java
@@ -16,6 +16,8 @@ import com.ceos.beatbuddy.domain.member.exception.MemberMoodErrorCode;
 import com.ceos.beatbuddy.domain.member.repository.*;
 import com.ceos.beatbuddy.domain.vector.entity.Vector;
 import com.ceos.beatbuddy.global.CustomException;
+import com.ceos.beatbuddy.global.config.jwt.redis.RefreshToken;
+import com.ceos.beatbuddy.global.config.jwt.redis.RefreshTokenRepository;
 import com.ceos.beatbuddy.global.config.oauth.dto.Oauth2MemberDto;
 import com.ceos.beatbuddy.global.util.UploadUtil;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +44,7 @@ public class MemberService {
     private final UploadUtil uploadUtil;
     private final MemberQueryRepository memberQueryRepository;
     private final FollowRepository followRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 //
 //    @Value("${iamport.api.key}")
 //    private String imp_key;
@@ -299,5 +302,25 @@ public class MemberService {
             return PostProfileInfo.from(null, null);
         }
         return PostProfileInfo.from(member.getPostProfileInfo().getPostProfileNickname(), member.getPostProfileInfo().getPostProfileImageUrl());
+    }
+
+    /**
+     * 사용자 로그아웃
+     * Redis에서 해당 사용자의 모든 refresh token을 삭제
+     */
+    @Transactional
+    public void logout(Long memberId) {
+        Member member = validateAndGetMember(memberId);
+
+        // Redis에서 해당 사용자의 모든 refresh token을 효율적으로 삭제
+        refreshTokenRepository.deleteAllByUserId(memberId);
+    }
+
+    /**
+     * 회원 탈퇴 (기존 deleteMember를 래핑하여 명확한 의미 부여)
+     */
+    @Transactional
+    public String withdrawMember(Long memberId) {
+        return deleteMember(memberId);
     }
 }

--- a/src/main/java/com/ceos/beatbuddy/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/member/controller/MemberController.java
@@ -356,6 +356,45 @@ public class MemberController implements MemberApiDocs{
                 .status(SuccessCode.SUCCESS_BLOCK_MEMBER.getStatus().value())
                 .body(new ResponseDTO<>(SuccessCode.SUCCESS_BLOCK_MEMBER, "성공적으로 차단했습니다."));
     }
+
+    // ============= Authentication Endpoints =============
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "사용자 로그아웃을 처리합니다. Redis에서 refresh token을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseDTO.class))),
+            @ApiResponse(responseCode = "404", description = "요청한 유저가 존재하지 않습니다",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseTemplate.class)))
+    })
+    public ResponseEntity<ResponseDTO<String>> logout() {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        memberService.logout(memberId);
+        return ResponseEntity
+                .status(SuccessCode.SUCCESS_LOGOUT.getStatus().value())
+                .body(new ResponseDTO<>(SuccessCode.SUCCESS_LOGOUT, "로그아웃 되었습니다."));
+    }
+
+    @DeleteMapping("/withdraw")
+    @Operation(summary = "회원 탈퇴",
+            description = "회원탈퇴를 진행합니다. 사용자의 모든 데이터(장르, 지역, 분위기 선호도, 하트비트, 아카이브)가 삭제됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원탈퇴 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseDTO.class))),
+            @ApiResponse(responseCode = "404", description = "요청한 유저가 존재하지 않습니다",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseTemplate.class)))
+    })
+    public ResponseEntity<ResponseDTO<String>> withdraw() {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        memberService.withdrawMember(memberId);
+        return ResponseEntity
+                .status(SuccessCode.SUCCESS_WITHDRAW.getStatus().value())
+                .body(new ResponseDTO<>(SuccessCode.SUCCESS_WITHDRAW, "회원탈퇴가 완료되었습니다."));
+    }
     
 //    @DeleteMapping("/block/{blockedMemberId}")
 //    public ResponseEntity<ResponseDTO<String>> unblockMember(@PathVariable @NotNull(message = "차단을 해제할 멤버 ID 는 필수입니다.") Long blockedMemberId) {

--- a/src/main/java/com/ceos/beatbuddy/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ceos/beatbuddy/domain/member/controller/MemberController.java
@@ -357,45 +357,6 @@ public class MemberController implements MemberApiDocs{
                 .body(new ResponseDTO<>(SuccessCode.SUCCESS_BLOCK_MEMBER, "성공적으로 차단했습니다."));
     }
 
-    // ============= Authentication Endpoints =============
-
-    @PostMapping("/logout")
-    @Operation(summary = "로그아웃", description = "사용자 로그아웃을 처리합니다. Redis에서 refresh token을 삭제합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그아웃 성공",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ResponseDTO.class))),
-            @ApiResponse(responseCode = "404", description = "요청한 유저가 존재하지 않습니다",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ResponseTemplate.class)))
-    })
-    public ResponseEntity<ResponseDTO<String>> logout() {
-        Long memberId = SecurityUtils.getCurrentMemberId();
-        memberService.logout(memberId);
-        return ResponseEntity
-                .status(SuccessCode.SUCCESS_LOGOUT.getStatus().value())
-                .body(new ResponseDTO<>(SuccessCode.SUCCESS_LOGOUT, "로그아웃 되었습니다."));
-    }
-
-    @DeleteMapping("/withdraw")
-    @Operation(summary = "회원 탈퇴",
-            description = "회원탈퇴를 진행합니다. 사용자의 모든 데이터(장르, 지역, 분위기 선호도, 하트비트, 아카이브)가 삭제됩니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원탈퇴 성공",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ResponseDTO.class))),
-            @ApiResponse(responseCode = "404", description = "요청한 유저가 존재하지 않습니다",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ResponseTemplate.class)))
-    })
-    public ResponseEntity<ResponseDTO<String>> withdraw() {
-        Long memberId = SecurityUtils.getCurrentMemberId();
-        memberService.withdrawMember(memberId);
-        return ResponseEntity
-                .status(SuccessCode.SUCCESS_WITHDRAW.getStatus().value())
-                .body(new ResponseDTO<>(SuccessCode.SUCCESS_WITHDRAW, "회원탈퇴가 완료되었습니다."));
-    }
-    
 //    @DeleteMapping("/block/{blockedMemberId}")
 //    public ResponseEntity<ResponseDTO<String>> unblockMember(@PathVariable @NotNull(message = "차단을 해제할 멤버 ID 는 필수입니다.") Long blockedMemberId) {
 //        Long memberId = SecurityUtils.getCurrentMemberId();

--- a/src/main/java/com/ceos/beatbuddy/global/code/SuccessCode.java
+++ b/src/main/java/com/ceos/beatbuddy/global/code/SuccessCode.java
@@ -16,6 +16,7 @@ public enum SuccessCode implements ApiCode {
     SUCCESS_REGISTER(HttpStatus.OK, "회원가입을 성공했습니다."),
     SUCCESS_LOGIN(HttpStatus.OK, "로그인을 성공했습니다. 헤더 토큰을 확인하세요."),
     SUCCESS_LOGOUT(HttpStatus.OK, "성공적으로 로그아웃했습니다."),
+    SUCCESS_WITHDRAW(HttpStatus.OK, "성공적으로 회원탈퇴했습니다."),
 
     /**
      * Member

--- a/src/main/java/com/ceos/beatbuddy/global/config/jwt/redis/RefreshTokenRepository.java
+++ b/src/main/java/com/ceos/beatbuddy/global/config/jwt/redis/RefreshTokenRepository.java
@@ -1,7 +1,10 @@
 package com.ceos.beatbuddy.global.config.jwt.redis;
 
 import org.springframework.data.repository.CrudRepository;
+import java.util.List;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
     RefreshToken findByUserId(Long userId);
+    List<RefreshToken> findAllByUserId(Long userId);
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/ceos/beatbuddy/global/config/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ceos/beatbuddy/global/config/oauth/OAuth2SuccessHandler.java
@@ -14,7 +14,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
@@ -99,8 +98,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             provider = "kakao";
         }
 
-        String redirectUrl = "https://beatbuddy.world/login/oauth2/callback/" + provider + "?access=" + access;
-
         LoginResponseDto loginResponseDto = LoginResponseDto.builder()
                 .memberId(memberId)
                 .loginId(username)
@@ -109,29 +106,17 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .refreshToken(refresh)
                 .build();
 
-        log.info("saved: " + access);
+        log.info("Login successful for memberId: {}", memberId);
 
-        ResponseCookie cookie = ResponseCookie.from("refresh", refresh)
-                .path("/")
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("None")
-                .maxAge(60 * 60 * 24 * 14)
-                .build();
-
-        response.addHeader("Set-Cookie", cookie.toString());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_OK);
 
         String jsonResponse = objectMapper.writeValueAsString(loginResponseDto);
         response.getWriter().write(jsonResponse);
 
         HttpSession session = request.getSession();
         session.setMaxInactiveInterval(600);
-
-        if (!response.isCommitted()) {
-            response.sendRedirect(redirectUrl);
-        }
     }
 
     private void saveRefreshToken(Long userId, String refresh) {

--- a/src/main/java/com/ceos/beatbuddy/global/config/oauth/controller/Oauth2Controller.java
+++ b/src/main/java/com/ceos/beatbuddy/global/config/oauth/controller/Oauth2Controller.java
@@ -1,8 +1,12 @@
 package com.ceos.beatbuddy.global.config.oauth.controller;
 
+import com.ceos.beatbuddy.domain.member.application.MemberService;
 import com.ceos.beatbuddy.global.ResponseTemplate;
+import com.ceos.beatbuddy.global.code.SuccessCode;
 import com.ceos.beatbuddy.global.config.jwt.SecurityUtils;
 import com.ceos.beatbuddy.global.config.oauth.application.Oauth2Service;
+import com.ceos.beatbuddy.global.dto.ResponseDTO;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,55 +27,93 @@ import org.springframework.web.bind.annotation.RestController;
 public class Oauth2Controller {
 
     private final Oauth2Service oauth2Service;
+    private final MemberService memberService;
 
-    @GetMapping("/logout")
-    @Operation(summary = "로그아웃",
-            description = "로그아웃을 진행합니다.\n"
-                    + "로그아웃을 진행하면 세션이 종료되고 Refresh 토큰이 만료됩니다.\n"
-                    + "로그아웃 후 다시 로그인을 진행해야 합니다")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "로그아웃에 성공했습니다. 본문은 로그아웃한 유저의 kakao id입니다."
-                    , content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = String.class))
-            ),
-            @ApiResponse(responseCode = "400", description = "잘못된 토큰입니다"
-                    + "\n에러 메시지가 출력됩니다.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class))),
-            @ApiResponse(responseCode = "404", description = "유저가 존재하지 않습니다",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ResponseTemplate.class)))
+    // @GetMapping("/logout")
+    // @Operation(summary = "로그아웃",
+    //         description = "로그아웃을 진행합니다.\n"
+    //                 + "로그아웃을 진행하면 세션이 종료되고 Refresh 토큰이 만료됩니다.\n"
+    //                 + "로그아웃 후 다시 로그인을 진행해야 합니다")
+    // @ApiResponses(value = {
+    //         @ApiResponse(responseCode = "200", description = "로그아웃에 성공했습니다. 본문은 로그아웃한 유저의 kakao id입니다."
+    //                 , content = @Content(mediaType = "application/json",
+    //                 schema = @Schema(implementation = String.class))
+    //         ),
+    //         @ApiResponse(responseCode = "400", description = "잘못된 토큰입니다"
+    //                 + "\n에러 메시지가 출력됩니다.",
+    //                 content = @Content(mediaType = "application/json",
+    //                         schema = @Schema(implementation = String.class))),
+    //         @ApiResponse(responseCode = "404", description = "유저가 존재하지 않습니다",
+    //                 content = @Content(mediaType = "application/json",
+    //                         schema = @Schema(implementation = ResponseTemplate.class)))
+    // })
+    // public ResponseEntity<String> kakaoLogout(HttpSession session) {
+    //     session.invalidate();
+    //     Long memberId = SecurityUtils.getCurrentMemberId();
+    //     String result = oauth2Service.logout(memberId);
+    //     return ResponseEntity.ok(result);
+    // }
+    //
+    // @PostMapping("/resign")
+    // @Operation(summary = "회원탈퇴",
+    //         description = "회원탈퇴를 진행합니다.\n"
+    //                 + "회원탈퇴를 진행하면 유저의 대한 장르,지역,분위기들의 선호도와 하트비트,아카이브가 전부 삭제됩니다.\n"
+    //                 + "탈퇴가 완료되면 로그아웃됩니다.")
+    // @ApiResponses(value = {
+    //         @ApiResponse(responseCode = "200", description = "회원탈퇴에 성공했습니다. 본문은 회원탈퇴한 유저의 kakao id입니다."
+    //                 , content = @Content(mediaType = "application/json",
+    //                 schema = @Schema(implementation = String.class))
+    //         ),
+    //         @ApiResponse(responseCode = "400", description = "잘못된 토큰입니다"
+    //                 + "\n에러 메시지가 출력됩니다.",
+    //                 content = @Content(mediaType = "application/json",
+    //                         schema = @Schema(implementation = String.class))),
+    //         @ApiResponse(responseCode = "404", description = "유저가 존재하지 않습니다",
+    //                 content = @Content(mediaType = "application/json",
+    //                         schema = @Schema(implementation = ResponseTemplate.class)))
+    // })
+    // public ResponseEntity<String> kakaoResign(HttpSession session) {
+    //     session.invalidate();
+    //     Long memberId = SecurityUtils.getCurrentMemberId();
+    //     String result = oauth2Service.resign(memberId);
+    //     return ResponseEntity.ok(result);
+    // }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "사용자 로그아웃을 처리합니다. Redis에서 refresh token을 삭제합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "로그아웃 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ResponseDTO.class))),
+        @ApiResponse(responseCode = "404", description = "요청한 유저가 존재하지 않습니다",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ResponseTemplate.class)))
     })
-    public ResponseEntity<String> kakaoLogout(HttpSession session) {
-        session.invalidate();
+    public ResponseEntity<ResponseDTO<String>> logout() {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        String result = oauth2Service.logout(memberId);
-        return ResponseEntity.ok(result);
+        memberService.logout(memberId);
+        return ResponseEntity
+            .status(SuccessCode.SUCCESS_LOGOUT.getStatus().value())
+            .body(new ResponseDTO<>(SuccessCode.SUCCESS_LOGOUT, "로그아웃 되었습니다."));
     }
 
-    @PostMapping("/resign")
-    @Operation(summary = "회원탈퇴",
-            description = "회원탈퇴를 진행합니다.\n"
-                    + "회원탈퇴를 진행하면 유저의 대한 장르,지역,분위기들의 선호도와 하트비트,아카이브가 전부 삭제됩니다.\n"
-                    + "탈퇴가 완료되면 로그아웃됩니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "회원탈퇴에 성공했습니다. 본문은 회원탈퇴한 유저의 kakao id입니다."
-                    , content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = String.class))
-            ),
-            @ApiResponse(responseCode = "400", description = "잘못된 토큰입니다"
-                    + "\n에러 메시지가 출력됩니다.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class))),
-            @ApiResponse(responseCode = "404", description = "유저가 존재하지 않습니다",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ResponseTemplate.class)))
+    @DeleteMapping("/withdraw")
+    @Operation(summary = "회원 탈퇴",
+        description = "회원탈퇴를 진행합니다. 사용자의 모든 데이터(장르, 지역, 분위기 선호도, 하트비트, 아카이브)가 삭제됩니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "회원탈퇴 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ResponseDTO.class))),
+        @ApiResponse(responseCode = "404", description = "요청한 유저가 존재하지 않습니다",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ResponseTemplate.class)))
     })
-    public ResponseEntity<String> kakaoResign(HttpSession session) {
-        session.invalidate();
+    public ResponseEntity<ResponseDTO<String>> withdraw() {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        String result = oauth2Service.resign(memberId);
-        return ResponseEntity.ok(result);
+        memberService.withdrawMember(memberId);
+        return ResponseEntity
+            .status(SuccessCode.SUCCESS_WITHDRAW.getStatus().value())
+            .body(new ResponseDTO<>(SuccessCode.SUCCESS_WITHDRAW, "회원탈퇴가 완료되었습니다."));
     }
 
 

--- a/src/main/java/com/ceos/beatbuddy/global/config/oauth/dto/TokenResponseDto.java
+++ b/src/main/java/com/ceos/beatbuddy/global/config/oauth/dto/TokenResponseDto.java
@@ -1,0 +1,32 @@
+package com.ceos.beatbuddy.global.config.oauth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Builder
+@Schema(description = "토큰 응답 DTO")
+public class TokenResponseDto {
+
+    @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String accessToken;
+
+    @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String refreshToken;
+
+    @Schema(description = "토큰 타입", example = "Bearer")
+    private String tokenType;
+
+    @Schema(description = "액세스 토큰 만료 시간 (초)", example = "7200")
+    private Long expiresIn;
+
+    public TokenResponseDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.tokenType = "Bearer";
+        this.expiresIn = 7200L; // 2시간 (1000 * 60 * 60 * 2L / 1000)
+    }
+}


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호
#437 

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #437 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용
- 로그아웃 기능 구현
- 회원탈퇴 기능 구현

## 📢 To Reviewers

-1. 기존의 저희 백엔드 시스템은 웹 기반 oauth2 소셜 로그인만을 고련 구조로 되어있어서 로그인 성공 시 access token과 refresh token을 cookie로 전달하고 있었는데 이건 모바일 웹에서 사용하기 어려운 방식이어서 response body로 토큰 전달하도록 바꿨습니다. 그래서 TokenResponseDto 클래스로 json 응답으로 변경했습니다. 그리고 reissue 엔드포인트에서 cookie 헤더 대신 Authorization 헤더에서 refresh token을 받도록 수정했습니다. 그래서 응답도 cookie가 아닌 json 바디로 새로운 토큰을 반환하도록 했습니다.
2. 로그아웃 메서드를 추가해서 redis에서 해당 사용자의 모든 refresh token을 삭제하도록 구현했습니다. 
현재 refresh repository를 보면 primary key가 refresh token string으로 도이엉ㅆ고, fk가 memberId로 도이어있습니다. 이건 memberId가 여러개의 refresh token을 가질 수 있다는 의미라서 해당 logout service 를 github 에서 확인하실 수 있다시피 구현했습니다.
3. 양방향 매핑이 되어있지 않으므로 cascade 기능을 활용할 수 없어서(양방향 매핑 코드를 작성할 수 있지만 컨벤션에 안 맞는 거 같아서 안 했습니다.) repository를 직접 이용해서 Delete 했습니다. 

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->